### PR TITLE
fix: green CI — clippy warnings + browser test

### DIFF
--- a/crates/cdp-runner/tests/cdp.rs
+++ b/crates/cdp-runner/tests/cdp.rs
@@ -1,6 +1,11 @@
 #[test]
 fn cdp_flow() {
-    std::env::set_var("CDP_HEADLESS", "0");
     let result = cdp_runner::run(cdp_runner::Config::default());
+    if let Err(ref e) = result {
+        if e == "chrome binary not found" {
+            eprintln!("SKIP: no Chrome/Chromium binary found, skipping CDP integration test");
+            return;
+        }
+    }
     assert!(result.is_ok(), "cdp runner failed: {:?}", result.err());
 }

--- a/crates/ui-core/src/form.rs
+++ b/crates/ui-core/src/form.rs
@@ -371,14 +371,12 @@ impl Form {
                             }
                         }
                     }
-                } else {
-                    if let Some(state) = self.state.fields.get(&field_path) {
-                        if let FieldValue::Group(group) = &state.value {
-                            for child in fields {
-                                if let Some(value) = group.get(&child.id) {
-                                    let child_path = field_path.push(child.id.clone());
-                                    out.extend(validate_value(&child_path, value, &child.rules));
-                                }
+                } else if let Some(state) = self.state.fields.get(&field_path) {
+                    if let FieldValue::Group(group) = &state.value {
+                        for child in fields {
+                            if let Some(value) = group.get(&child.id) {
+                                let child_path = field_path.push(child.id.clone());
+                                out.extend(validate_value(&child_path, value, &child.rules));
                             }
                         }
                     }

--- a/crates/ui-core/src/text.rs
+++ b/crates/ui-core/src/text.rs
@@ -495,12 +495,10 @@ impl TextBuffer {
         if grapheme_index == 0 {
             return 0;
         }
-        let mut count = 0;
-        for (byte_index, _) in self.text.grapheme_indices(true) {
+        for (count, (byte_index, _)) in self.text.grapheme_indices(true).enumerate() {
             if count == grapheme_index {
                 return byte_index;
             }
-            count += 1;
         }
         self.text.len()
     }

--- a/crates/ui-core/src/ui.rs
+++ b/crates/ui-core/src/ui.rs
@@ -520,7 +520,7 @@ impl Ui {
         });
 
         if focused {
-            let show_caret = (self.time_ms as u64 / 500) % 2 == 0;
+            let show_caret = (self.time_ms as u64 / 500).is_multiple_of(2);
             if show_caret {
                 let caret_pos = self.index_to_position(rect, buffer, buffer.caret().index, multiline);
                 let caret_rect = Rect::new(caret_pos.x, caret_pos.y, 1.5, 18.0 * self.scale);
@@ -831,8 +831,7 @@ impl Ui {
         let line_height = font_size * 1.4;
         let char_width = font_size * 0.6;
         let mut remaining = index;
-        let mut line = 0;
-        for line_text in buffer.text().split('\n') {
+        for (line, line_text) in buffer.text().split('\n').enumerate() {
             let graphemes = line_text.graphemes(true).count();
             if remaining <= graphemes {
                 let x = rect.x + padding + remaining as f32 * char_width;
@@ -840,7 +839,6 @@ impl Ui {
                 return Vec2::new(x, y);
             }
             remaining = remaining.saturating_sub(graphemes + 1);
-            line += 1;
         }
         Vec2::new(rect.x + padding, rect.y + padding)
     }

--- a/crates/ui-core/src/validation.rs
+++ b/crates/ui-core/src/validation.rs
@@ -1,5 +1,11 @@
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+use std::sync::OnceLock;
+
+fn email_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"^[^\s@]+@[^\s@]+\.[^\s@]+$").expect("valid email regex"))
+}
 
 use crate::form::{FieldValue, FormPath};
 
@@ -72,14 +78,11 @@ pub fn validate_value(path: &FormPath, value: &FieldValue, rules: &[ValidationRu
             }
             ValidationRule::Email => {
                 if let FieldValue::Text(text) = value {
-                    let re = Regex::new(r"^[^\s@]+@[^\s@]+\.[^\s@]+$");
-                    if let Ok(re) = re {
-                        if !re.is_match(text) {
-                            errors.push(ValidationError {
-                                path: path.clone(),
-                                message: "Please enter a valid email address.".to_string(),
-                            });
-                        }
+                    if !email_regex().is_match(text) {
+                        errors.push(ValidationError {
+                            path: path.clone(),
+                            message: "Please enter a valid email address.".to_string(),
+                        });
                     }
                 }
             }


### PR DESCRIPTION
Closes #40

## Summary

- **Clippy (5 warnings → 0):** `collapsible_else_if`, two `explicit_counter_loop`s, `manual_is_multiple_of`, `regex_creation_in_loops` — all fixed at the source
- **Browser test:** the test was setting `CDP_HEADLESS=0`, overriding CI's `CDP_HEADLESS=1` and causing Chromium to require a display that doesn't exist on the runner; removed the override and added a graceful skip when no browser binary is found locally

## Test plan

- [ ] `cargo clippy -p ui-core --all-features -- -D warnings` exits 0
- [ ] `cargo test -p ui-core --all-features` passes
- [ ] `cargo test -p cdp-runner -- --nocapture` passes (skips gracefully locally, runs headless in CI)
- [ ] CI "CI" workflow passes green
- [ ] CI "Browser Tests" workflow passes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)