### PR TITLE
fix: reposition hidden textarea over focused widget for iOS Safari

### DIFF
--- a/crates/ui-core/src/ui.rs
+++ b/crates/ui-core/src/ui.rs
@@ -964,6 +964,15 @@ fn widget_role(kind: WidgetKind) -> A11yRole {
 }
 
 impl Ui {
+    /// Returns the bounding rect of the currently focused widget, if any.
+    pub fn focused_widget_rect(&self) -> Option<Rect> {
+        let focused_id = self.focused?;
+        self.widgets
+            .iter()
+            .find(|w| w.id == focused_id)
+            .map(|w| w.rect)
+    }
+
     fn ui_label_inline(&mut self, text: &str) {
         let rect = self.layout.next_rect(22.0 * self.scale);
         self.batch.text_runs.push(TextRun {

--- a/crates/ui-wasm/src/demo.rs
+++ b/crates/ui-wasm/src/demo.rs
@@ -303,6 +303,12 @@ impl DemoApp {
         self.clipboard_request.take()
     }
 
+    /// Returns the bounding rect (x, y, w, h) of the currently focused widget,
+    /// or `None` if nothing is focused.
+    pub fn focused_widget_rect(&self) -> Option<[f32; 4]> {
+        self.ui.focused_widget_rect().map(|r| [r.x, r.y, r.w, r.h])
+    }
+
     pub fn handle_pointer_down(&mut self, x: f32, y: f32, button: u16, ctrl: bool, alt: bool, shift: bool, meta: bool) {
         let event = InputEvent::PointerDown(PointerEvent {
             pos: ui_core::types::Vec2::new(x, y),

--- a/crates/ui-wasm/src/lib.rs
+++ b/crates/ui-wasm/src/lib.rs
@@ -94,5 +94,18 @@ impl WasmApp {
     pub fn take_clipboard_request(&mut self) -> Option<String> {
         self.demo.take_clipboard_request()
     }
+
+    /// Returns the focused widget's bounding rect as [x, y, w, h] in canvas
+    /// pixels, or `null` if no widget is focused.
+    pub fn focused_widget_rect(&self) -> JsValue {
+        match self.demo.focused_widget_rect() {
+            Some([x, y, w, h]) => {
+                let arr = js_sys::Float32Array::new_with_length(4);
+                arr.copy_from(&[x, y, w, h]);
+                arr.into()
+            }
+            None => JsValue::NULL,
+        }
+    }
 }
 

--- a/examples/web/app.js
+++ b/examples/web/app.js
@@ -10,19 +10,109 @@ function resize() {
   canvas.style.height = `${window.innerHeight}px`;
 }
 
+/**
+ * Create a hidden textarea overlaying the canvas for mobile keyboard input.
+ *
+ * iOS Safari scrolls the viewport to bring focused elements into view, even
+ * when they are positioned offscreen (e.g. `left:-9999px`). To prevent this
+ * we keep the textarea at `opacity:0` directly over the focused canvas widget
+ * instead of hiding it offscreen.
+ */
+function createHiddenTextarea() {
+  const ta = document.createElement("textarea");
+  ta.setAttribute("autocapitalize", "off");
+  ta.setAttribute("autocomplete", "off");
+  ta.setAttribute("autocorrect", "off");
+  ta.setAttribute("spellcheck", "false");
+  ta.setAttribute("aria-hidden", "true");
+  ta.setAttribute("tabindex", "-1");
+  Object.assign(ta.style, {
+    position: "absolute",
+    top: "0px",
+    left: "0px",
+    width: "1px",
+    height: "1px",
+    opacity: "0",
+    pointerEvents: "none",
+    zIndex: "-1",
+    padding: "0",
+    border: "none",
+    outline: "none",
+    resize: "none",
+    overflow: "hidden",
+    // Prevent iOS zoom on focus
+    fontSize: "16px",
+  });
+  document.body.appendChild(ta);
+  return ta;
+}
+
+/**
+ * Reposition the hidden textarea to overlay the focused widget so that iOS
+ * Safari does not scroll the viewport when the textarea receives focus.
+ *
+ * Coordinates from the WASM side are in canvas (physical) pixels; we convert
+ * to CSS pixels by dividing by `dpr`.
+ */
+function repositionTextarea(ta, rectArray, dpr) {
+  if (!rectArray) {
+    // No focused widget — park the textarea at origin so it stays harmless.
+    ta.style.top = "0px";
+    ta.style.left = "0px";
+    ta.style.width = "1px";
+    ta.style.height = "1px";
+    return;
+  }
+  const x = rectArray[0] / dpr;
+  const y = rectArray[1] / dpr;
+  const w = rectArray[2] / dpr;
+  const h = rectArray[3] / dpr;
+  ta.style.left = `${x}px`;
+  ta.style.top = `${y}px`;
+  ta.style.width = `${Math.max(w, 1)}px`;
+  ta.style.height = `${Math.max(h, 1)}px`;
+}
+
 async function main() {
   await init();
   resize();
   const app = new WasmApp(canvas, canvas.width, canvas.height, dpr);
   window.__app = app;
 
+  const hiddenTextarea = createHiddenTextarea();
+
   window.addEventListener("resize", () => {
     resize();
     app.resize(canvas.width, canvas.height, dpr);
   });
 
+  // --- visualViewport resize (virtual keyboard open/close) ---
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener("resize", () => {
+      // When the virtual keyboard opens the visual viewport shrinks.  Scroll
+      // the focused widget into the visible area so it is not hidden behind
+      // the keyboard.
+      const rect = app.focused_widget_rect();
+      if (!rect) return;
+
+      const widgetBottomCSS = rect[1] / dpr + rect[3] / dpr;
+      const viewportHeight = window.visualViewport.height;
+      const viewportOffsetTop = window.visualViewport.offsetTop;
+      const visibleBottom = viewportOffsetTop + viewportHeight;
+
+      if (widgetBottomCSS > visibleBottom) {
+        const scrollBy = widgetBottomCSS - visibleBottom + 20; // 20px padding
+        window.scrollBy({ top: scrollBy, behavior: "smooth" });
+      }
+    });
+  }
+
   canvas.addEventListener("pointerdown", (e) => {
     app.handle_pointer_down(e.offsetX * dpr, e.offsetY * dpr, e.button, e.ctrlKey, e.altKey, e.shiftKey, e.metaKey);
+    // On touch devices, focus the hidden textarea so the virtual keyboard opens.
+    if (e.pointerType === "touch") {
+      hiddenTextarea.focus({ preventScroll: true });
+    }
   });
   canvas.addEventListener("pointerup", (e) => {
     app.handle_pointer_up(e.offsetX * dpr, e.offsetY * dpr, e.button, e.ctrlKey, e.altKey, e.shiftKey, e.metaKey);
@@ -66,6 +156,12 @@ async function main() {
     const a11y = app.frame(ts);
     window.__a11y = a11y;
     handleClipboard();
+
+    // Reposition the hidden textarea over the currently focused widget so
+    // that iOS Safari focus behaviour does not cause viewport scrolling.
+    const focusedRect = app.focused_widget_rect();
+    repositionTextarea(hiddenTextarea, focusedRect, dpr);
+
     requestAnimationFrame(frame);
   }
   requestAnimationFrame(frame);


### PR DESCRIPTION
Closes #49