### PR TITLE
ci: upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       # ── Checkout ─────────────────────────────────────────────────────────────
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # ── Rust toolchain ───────────────────────────────────────────────────────
       - name: Install Rust stable + wasm32 target
@@ -26,7 +26,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -76,7 +76,7 @@ jobs:
       # ── Upload screenshots as artifacts ──────────────────────────────────────
       - name: Upload screenshots
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: browser-screenshots-${{ github.run_number }}
           path: screenshots/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,13 @@ jobs:
     name: cargo test (ui-core)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry + build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -38,7 +38,7 @@ jobs:
     name: cargo check (wasm32)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust stable + wasm32 target
         uses: dtolnay/rust-toolchain@stable
@@ -46,7 +46,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -63,7 +63,7 @@ jobs:
     name: clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust stable + clippy
         uses: dtolnay/rust-toolchain@stable
@@ -71,7 +71,7 @@ jobs:
           components: clippy
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
## Summary
- `actions/checkout` v4 → v6
- `actions/cache` v4 → v5
- `actions/upload-artifact` v4 → v7
- Updated in both `ci.yml` and `browser-tests.yml`
- Deadline: June 2, 2026

Closes #62

## Test plan
- [ ] CI workflow runs successfully on this PR
- [ ] Browser tests workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)