### PR TITLE
fix(ui-core): cap form history stack to prevent OOM

### DIFF
--- a/crates/ui-core/src/state.rs
+++ b/crates/ui-core/src/state.rs
@@ -1,5 +1,9 @@
 use std::sync::Arc;
 
+/// Maximum number of past states retained in the history stack.
+/// Prevents unbounded memory growth (OOM) when users make many edits.
+const MAX_HISTORY_ENTRIES: usize = 100;
+
 #[derive(Clone, Debug)]
 pub struct History<T> {
     past: Vec<Arc<T>>,
@@ -23,8 +27,22 @@ impl<T> History<T> {
     pub fn push(&mut self, next: T) {
         let current = self.present.clone();
         self.past.push(current);
+        if self.past.len() > MAX_HISTORY_ENTRIES {
+            let excess = self.past.len() - MAX_HISTORY_ENTRIES;
+            self.past.drain(..excess);
+        }
         self.present = Arc::new(next);
         self.future.clear();
+    }
+
+    /// Returns the maximum number of past states retained.
+    pub fn max_entries() -> usize {
+        MAX_HISTORY_ENTRIES
+    }
+
+    /// Returns the current number of past states.
+    pub fn past_len(&self) -> usize {
+        self.past.len()
     }
 
     pub fn can_undo(&self) -> bool {
@@ -49,6 +67,79 @@ impl<T> History<T> {
         self.past.push(current);
         self.present = next.clone();
         Some(next)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn history_push_and_undo() {
+        let mut h = History::new(0u32);
+        h.push(1);
+        h.push(2);
+        assert_eq!(*h.present(), 2);
+        assert_eq!(h.past_len(), 2);
+
+        h.undo();
+        assert_eq!(*h.present(), 1);
+    }
+
+    #[test]
+    fn history_cap_limits_past_entries() {
+        let mut h = History::new(0u32);
+        for i in 1..=(MAX_HISTORY_ENTRIES + 50) {
+            h.push(i as u32);
+        }
+        assert_eq!(h.past_len(), MAX_HISTORY_ENTRIES);
+        // The oldest entries should have been drained; the earliest
+        // remaining past entry is 51 (we pushed 1..=150, kept last 100
+        // past entries which are 51..=150, present is 150).
+        assert_eq!(*h.present(), (MAX_HISTORY_ENTRIES + 50) as u32);
+    }
+
+    #[test]
+    fn history_cap_oldest_entries_are_dropped() {
+        let mut h = History::new(0u32);
+        for i in 1..=(MAX_HISTORY_ENTRIES + 10) {
+            h.push(i as u32);
+        }
+        // Undo all the way back -- we should only be able to undo
+        // MAX_HISTORY_ENTRIES times since older entries were evicted.
+        let mut undo_count = 0;
+        while h.undo().is_some() {
+            undo_count += 1;
+        }
+        assert_eq!(undo_count, MAX_HISTORY_ENTRIES);
+        // After undoing everything, present should be the oldest
+        // surviving past entry (value 10, which was the present
+        // before pushing value 11).
+        assert_eq!(*h.present(), 10);
+    }
+
+    #[test]
+    fn history_cap_does_not_affect_small_stacks() {
+        let mut h = History::new(0u32);
+        for i in 1..5 {
+            h.push(i);
+        }
+        assert_eq!(h.past_len(), 4);
+        assert_eq!(*h.present(), 4);
+    }
+
+    #[test]
+    fn history_redo_after_cap() {
+        let mut h = History::new(0u32);
+        for i in 1..=(MAX_HISTORY_ENTRIES + 5) {
+            h.push(i as u32);
+        }
+        // Undo a few, then redo -- future stack should work normally
+        h.undo();
+        h.undo();
+        assert!(h.can_redo());
+        h.redo();
+        assert_eq!(*h.present(), (MAX_HISTORY_ENTRIES + 4) as u32);
     }
 }
 


### PR DESCRIPTION
## Summary
- Added `MAX_HISTORY_ENTRIES = 100` cap on the history stack
- Oldest entries are drained when the cap is exceeded on push
- Added `max_entries()` and `past_len()` helpers
- Added 5 unit tests covering cap enforcement, eviction, and edge cases

Closes #64

## Test plan
- [x] `cargo test -p ui-core` passes (5 new tests)
- [x] Verified oldest entries are evicted, not newest

🤖 Generated with [Claude Code](https://claude.com/claude-code)