### PR TITLE
fix(ui): replace deprecated keyCode with e.code/e.key

### DIFF
--- a/crates/ui-core/src/input.rs
+++ b/crates/ui-core/src/input.rs
@@ -23,7 +23,12 @@ pub struct PointerEvent {
     pub modifiers: Modifiers,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// Physical key identifiers matching the Web KeyboardEvent.code specification.
+///
+/// Named variants cover the keys used by the UI framework for shortcuts and
+/// navigation.  Any unrecognised physical key is represented as
+/// `Other(String)` carrying the raw `KeyboardEvent.code` value.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum KeyCode {
     Backspace,
     Delete,
@@ -45,7 +50,36 @@ pub enum KeyCode {
     X,
     Z,
     Y,
-    Other(u32),
+    Other(String),
+}
+
+impl KeyCode {
+    /// Parse a `KeyboardEvent.code` string into a `KeyCode`.
+    pub fn from_code_str(code: &str) -> Self {
+        match code {
+            "Backspace" => KeyCode::Backspace,
+            "Tab" => KeyCode::Tab,
+            "Enter" | "NumpadEnter" => KeyCode::Enter,
+            "Escape" => KeyCode::Escape,
+            "Insert" => KeyCode::Insert,
+            "Delete" => KeyCode::Delete,
+            "ArrowLeft" => KeyCode::ArrowLeft,
+            "ArrowUp" => KeyCode::ArrowUp,
+            "ArrowRight" => KeyCode::ArrowRight,
+            "ArrowDown" => KeyCode::ArrowDown,
+            "Home" => KeyCode::Home,
+            "End" => KeyCode::End,
+            "PageUp" => KeyCode::PageUp,
+            "PageDown" => KeyCode::PageDown,
+            "KeyA" => KeyCode::A,
+            "KeyC" => KeyCode::C,
+            "KeyV" => KeyCode::V,
+            "KeyX" => KeyCode::X,
+            "KeyZ" => KeyCode::Z,
+            "KeyY" => KeyCode::Y,
+            other => KeyCode::Other(other.to_string()),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/ui-wasm/src/demo.rs
+++ b/crates/ui-wasm/src/demo.rs
@@ -363,17 +363,17 @@ impl DemoApp {
         self.events.push(event);
     }
 
-    pub fn handle_key_down(&mut self, code: u32, ctrl: bool, alt: bool, shift: bool, meta: bool) {
+    pub fn handle_key_down(&mut self, code: &str, ctrl: bool, alt: bool, shift: bool, meta: bool) {
         let event = InputEvent::KeyDown {
-            code: map_key(code),
+            code: KeyCode::from_code_str(code),
             modifiers: Modifiers { ctrl, alt, shift, meta },
         };
         self.events.push(event);
     }
 
-    pub fn handle_key_up(&mut self, code: u32, ctrl: bool, alt: bool, shift: bool, meta: bool) {
+    pub fn handle_key_up(&mut self, code: &str, ctrl: bool, alt: bool, shift: bool, meta: bool) {
         let event = InputEvent::KeyUp {
-            code: map_key(code),
+            code: KeyCode::from_code_str(code),
             modifiers: Modifiers { ctrl, alt, shift, meta },
         };
         self.events.push(event);
@@ -433,31 +433,6 @@ fn map_button(button: u16) -> PointerButton {
     }
 }
 
-fn map_key(code: u32) -> KeyCode {
-    match code {
-        8  => KeyCode::Backspace,
-        9  => KeyCode::Tab,
-        13 => KeyCode::Enter,
-        27 => KeyCode::Escape,
-        45 => KeyCode::Insert,
-        46 => KeyCode::Delete,
-        37 => KeyCode::ArrowLeft,
-        38 => KeyCode::ArrowUp,
-        39 => KeyCode::ArrowRight,
-        40 => KeyCode::ArrowDown,
-        36 => KeyCode::Home,
-        35 => KeyCode::End,
-        33 => KeyCode::PageUp,
-        34 => KeyCode::PageDown,
-        65 => KeyCode::A,
-        67 => KeyCode::C,
-        86 => KeyCode::V,
-        88 => KeyCode::X,
-        90 => KeyCode::Z,
-        89 => KeyCode::Y,
-        other => KeyCode::Other(other),
-    }
-}
 
 fn login_schema() -> FormSchema {
     FormSchema {

--- a/crates/ui-wasm/src/lib.rs
+++ b/crates/ui-wasm/src/lib.rs
@@ -67,11 +67,11 @@ impl WasmApp {
         self.demo.handle_wheel(x, y, dx, dy, ctrl, alt, shift, meta);
     }
 
-    pub fn handle_key_down(&mut self, code: u32, ctrl: bool, alt: bool, shift: bool, meta: bool) {
+    pub fn handle_key_down(&mut self, code: &str, ctrl: bool, alt: bool, shift: bool, meta: bool) {
         self.demo.handle_key_down(code, ctrl, alt, shift, meta);
     }
 
-    pub fn handle_key_up(&mut self, code: u32, ctrl: bool, alt: bool, shift: bool, meta: bool) {
+    pub fn handle_key_up(&mut self, code: &str, ctrl: bool, alt: bool, shift: bool, meta: bool) {
         self.demo.handle_key_up(code, ctrl, alt, shift, meta);
     }
 

--- a/examples/web/app.js
+++ b/examples/web/app.js
@@ -264,7 +264,7 @@ async function main() {
     if (clipboardAction === "copy" || clipboardAction === "cut") {
       // Forward the key event to Wasm first so it populates the clipboard
       // request (selected text) and, for cut, deletes the selection.
-      app.handle_key_down(e.keyCode, e.ctrlKey, e.altKey, e.shiftKey, e.metaKey);
+      app.handle_key_down(e.code, e.ctrlKey, e.altKey, e.shiftKey, e.metaKey);
       // NOTE: After calling into Wasm, any cached typed-array views into
       // wasm.memory.buffer may be detached (memory.grow).  We only read a
       // JS string from take_clipboard_request(), so no view re-acquisition
@@ -295,7 +295,7 @@ async function main() {
       return;
     }
 
-    app.handle_key_down(e.keyCode, e.ctrlKey, e.altKey, e.shiftKey, e.metaKey);
+    app.handle_key_down(e.code, e.ctrlKey, e.altKey, e.shiftKey, e.metaKey);
 
     // Prevent browser defaults for keys that widgets handle when focused.
     // We check focus state AFTER forwarding to Wasm because the key event
@@ -305,14 +305,13 @@ async function main() {
         "Tab", "Backspace", "Enter", "Space",
         "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight",
       ]);
-      // Also prevent Space via its legacy key value " "
       if (PREVENT_KEYS.has(e.key) || PREVENT_KEYS.has(e.code)) {
         e.preventDefault();
       }
     }
   });
   window.addEventListener("keyup", (e) => {
-    app.handle_key_up(e.keyCode, e.ctrlKey, e.altKey, e.shiftKey, e.metaKey);
+    app.handle_key_up(e.code, e.ctrlKey, e.altKey, e.shiftKey, e.metaKey);
   });
   window.addEventListener("beforeinput", (e) => {
     if (e.data) {


### PR DESCRIPTION
## Summary
- Changed `KeyCode::Other(u32)` to `KeyCode::Other(String)` with `from_code_str()` mapping Web KeyboardEvent.code strings
- Updated app.js to send `e.code` instead of `e.keyCode`
- Updated wasm_bindgen bindings from `u32` to `&str`
- Removed old numeric `map_key()` in demo.rs

Closes #3

## Test plan
- [x] `cargo test -p ui-core` — 128 tests pass
- [x] `cargo build -p ui-wasm --target wasm32-unknown-unknown` compiles
- [ ] Manual: keyboard shortcuts work on QWERTY/AZERTY/Dvorak

🤖 Generated with [Claude Code](https://claude.com/claude-code)