### PR TITLE
fix(web): add preventDefault when widgets are focused

### DIFF
--- a/crates/ui-core/src/ui.rs
+++ b/crates/ui-core/src/ui.rs
@@ -1015,6 +1015,15 @@ impl Ui {
             .map(|w| w.rect)
     }
 
+    /// Returns the kind of the currently focused widget, if any.
+    pub fn focused_widget_kind(&self) -> Option<WidgetKind> {
+        let focused_id = self.focused?;
+        self.widgets
+            .iter()
+            .find(|w| w.id == focused_id)
+            .map(|w| w.kind)
+    }
+
     fn ui_label_inline(&mut self, text: &str) {
         let rect = self.layout.next_rect(22.0 * self.scale);
         self.batch.text_runs.push(TextRun {

--- a/crates/ui-wasm/src/demo.rs
+++ b/crates/ui-wasm/src/demo.rs
@@ -308,6 +308,25 @@ impl DemoApp {
         self.ui.focused_widget_rect().map(|r| [r.x, r.y, r.w, r.h])
     }
 
+    /// Returns `true` if any widget currently has focus.
+    pub fn has_focused_widget(&self) -> bool {
+        self.ui.focused.is_some()
+    }
+
+    /// Returns the kind of the focused widget as a string, or `None`.
+    pub fn focused_widget_kind_str(&self) -> Option<&'static str> {
+        use ui_core::ui::WidgetKind;
+        self.ui.focused_widget_kind().map(|k| match k {
+            WidgetKind::Label => "label",
+            WidgetKind::Button => "button",
+            WidgetKind::Checkbox => "checkbox",
+            WidgetKind::Radio => "radio",
+            WidgetKind::TextInput => "textinput",
+            WidgetKind::Select => "select",
+            WidgetKind::Group => "group",
+        })
+    }
+
     pub fn handle_pointer_down(&mut self, x: f32, y: f32, button: u16, ctrl: bool, alt: bool, shift: bool, meta: bool) {
         let event = InputEvent::PointerDown(PointerEvent {
             pos: ui_core::types::Vec2::new(x, y),

--- a/crates/ui-wasm/src/lib.rs
+++ b/crates/ui-wasm/src/lib.rs
@@ -115,6 +115,20 @@ impl WasmApp {
         self.renderer.reinitialize()
     }
 
+    /// Returns `true` if any widget currently has focus.
+    pub fn has_focused_widget(&self) -> bool {
+        self.demo.has_focused_widget()
+    }
+
+    /// Returns the kind of the focused widget as a string (e.g. "textinput",
+    /// "button"), or `null` if no widget is focused.
+    pub fn focused_widget_kind(&self) -> JsValue {
+        match self.demo.focused_widget_kind_str() {
+            Some(kind) => JsValue::from_str(kind),
+            None => JsValue::NULL,
+        }
+    }
+
     /// Returns the focused widget's bounding rect as [x, y, w, h] in canvas
     /// pixels, or `null` if no widget is focused.
     pub fn focused_widget_rect(&self) -> JsValue {

--- a/examples/web/app.js
+++ b/examples/web/app.js
@@ -246,7 +246,11 @@ async function main() {
   });
   canvas.addEventListener("wheel", (e) => {
     app.handle_wheel(e.offsetX * dpr, e.offsetY * dpr, e.deltaX, e.deltaY, e.ctrlKey, e.altKey, e.shiftKey, e.metaKey);
-  });
+    // Prevent the page from scrolling when the canvas has a focused widget.
+    if (app.has_focused_widget()) {
+      e.preventDefault();
+    }
+  }, { passive: false });
 
   window.addEventListener("keydown", (e) => {
     const clipboardAction = isClipboardShortcut(e);
@@ -286,6 +290,20 @@ async function main() {
     }
 
     app.handle_key_down(e.keyCode, e.ctrlKey, e.altKey, e.shiftKey, e.metaKey);
+
+    // Prevent browser defaults for keys that widgets handle when focused.
+    // We check focus state AFTER forwarding to Wasm because the key event
+    // may itself change focus (e.g. Tab moves focus to the next widget).
+    if (app.has_focused_widget()) {
+      const PREVENT_KEYS = new Set([
+        "Tab", "Backspace", "Enter", "Space",
+        "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight",
+      ]);
+      // Also prevent Space via its legacy key value " "
+      if (PREVENT_KEYS.has(e.key) || PREVENT_KEYS.has(e.code)) {
+        e.preventDefault();
+      }
+    }
   });
   window.addEventListener("keyup", (e) => {
     app.handle_key_up(e.keyCode, e.ctrlKey, e.altKey, e.shiftKey, e.metaKey);
@@ -293,6 +311,12 @@ async function main() {
   window.addEventListener("beforeinput", (e) => {
     if (e.data) {
       app.handle_text_input(e.data);
+    }
+    // Prevent the browser from inserting text into the hidden textarea (or
+    // any other focused DOM element) when a canvas text widget owns focus.
+    const kind = app.focused_widget_kind();
+    if (kind === "textinput" || kind === "select") {
+      e.preventDefault();
     }
   });
   window.addEventListener("compositionstart", () => app.handle_composition_start());


### PR DESCRIPTION
## Summary
- Exposed `has_focused_widget()` and `focused_widget_kind()` via wasm_bindgen
- keydown: preventDefault for Tab, Backspace, Enter, Space, arrows when widget focused
- wheel: preventDefault when widget focused (listener changed to `passive: false`)
- beforeinput: preventDefault when textinput/select focused
- No defaults prevented when no widget is focused

Closes #6

## Test plan
- [x] `cargo test -p ui-core` — 128 tests pass
- [x] Wasm build compiles
- [ ] Manual: Tab doesn't scroll page, Backspace doesn't navigate back

🤖 Generated with [Claude Code](https://claude.com/claude-code)