### PR TITLE
feat(ui-core): add password masking to text_input widget

### DIFF
--- a/crates/ui-core/src/ui.rs
+++ b/crates/ui-core/src/ui.rs
@@ -459,7 +459,11 @@ impl Ui {
     }
 
     pub fn text_input(&mut self, label: &str, buffer: &mut TextBuffer, placeholder: &str) -> bool {
-        self.text_input_impl(label, buffer, placeholder, false, 40.0 * self.scale)
+        self.text_input_impl(label, buffer, placeholder, false, false, 40.0 * self.scale)
+    }
+
+    pub fn text_input_masked(&mut self, label: &str, buffer: &mut TextBuffer, placeholder: &str) -> bool {
+        self.text_input_impl(label, buffer, placeholder, false, true, 40.0 * self.scale)
     }
 
     pub fn text_input_multiline(
@@ -469,7 +473,7 @@ impl Ui {
         placeholder: &str,
         height: f32,
     ) -> bool {
-        self.text_input_impl(label, buffer, placeholder, true, height)
+        self.text_input_impl(label, buffer, placeholder, true, false, height)
     }
 
     fn text_input_impl(
@@ -478,6 +482,7 @@ impl Ui {
         buffer: &mut TextBuffer,
         placeholder: &str,
         multiline: bool,
+        masked: bool,
         height: f32,
     ) -> bool {
         let rect = self.layout.next_rect(height);
@@ -504,6 +509,8 @@ impl Ui {
         );
         let content = if buffer.text().is_empty() {
             placeholder.to_string()
+        } else if masked {
+            "\u{2022}".repeat(buffer.grapheme_len())
         } else {
             buffer.text().to_string()
         };
@@ -1214,6 +1221,64 @@ mod tests {
     // -----------------------------------------------------------------------
     // begin_frame clears per-frame state
     // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // Password masking
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn masked_text_input_produces_bullet_text_runs() {
+        let mut ui = test_ui();
+        ui.begin_frame(vec![], 800.0, 600.0, 1.0, 0.0);
+        let mut buf = TextBuffer::new("secret");
+        ui.text_input_masked("Password", &mut buf, "");
+        // The text run should contain bullets, not the actual text
+        let text_run = ui.batch.text_runs.iter().find(|r| r.text.contains('\u{2022}')).unwrap();
+        assert_eq!(text_run.text, "\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}");
+        assert!(!ui.batch.text_runs.iter().any(|r| r.text.contains("secret")));
+    }
+
+    #[test]
+    fn masked_text_input_preserves_actual_value() {
+        let mut ui = test_ui();
+        ui.begin_frame(vec![], 800.0, 600.0, 1.0, 0.0);
+        let mut buf = TextBuffer::new("hunter2");
+        ui.text_input_masked("Password", &mut buf, "");
+        // The underlying text must remain unchanged
+        assert_eq!(buf.text(), "hunter2");
+        // The widget value in the a11y tree should also have the real text
+        let widget = ui.widgets.iter().find(|w| w.label == "Password").unwrap();
+        assert_eq!(widget.value.as_deref(), Some("hunter2"));
+    }
+
+    #[test]
+    fn masked_text_input_cursor_movement_works() {
+        let mut ui = test_ui();
+        let mut buf = TextBuffer::new("abc");
+        // Focus the password field so key events are processed
+        let id = ui.hash_id("Password");
+        ui.focused = Some(id);
+        // Simulate a left-arrow key event
+        let events = vec![InputEvent::KeyDown {
+            code: KeyCode::ArrowLeft,
+            modifiers: Modifiers { shift: false, ctrl: false, alt: false, meta: false },
+        }];
+        ui.begin_frame(events, 800.0, 600.0, 1.0, 0.0);
+        ui.text_input_masked("Password", &mut buf, "");
+        // Caret should have moved left by one
+        assert_eq!(buf.caret().index, 2);
+        assert_eq!(buf.text(), "abc");
+    }
+
+    #[test]
+    fn masked_empty_shows_placeholder() {
+        let mut ui = test_ui();
+        ui.begin_frame(vec![], 800.0, 600.0, 1.0, 0.0);
+        let mut buf = TextBuffer::new("");
+        ui.text_input_masked("Password", &mut buf, "enter password");
+        // Should show placeholder, not bullets
+        assert!(ui.batch.text_runs.iter().any(|r| r.text == "enter password"));
+    }
 
     #[test]
     fn begin_frame_clears_widgets_and_batch() {

--- a/crates/ui-wasm/src/demo.rs
+++ b/crates/ui-wasm/src/demo.rs
@@ -139,7 +139,7 @@ impl DemoApp {
         if self.auth_mode == 0 {
             self.ui.label("Login");
             self.ui.text_input("Email", &mut self.login_email, "email@example.com");
-            self.ui.text_input("Password", &mut self.login_password, "password");
+            self.ui.text_input_masked("Password", &mut self.login_password, "password");
             if self.ui.button("Submit Login") {
                 let mut form = self.login_form.clone();
                 let _ = form.set_value(&FormPath(vec!["email".into()]), FieldValue::Text(self.login_email.text().to_string()));
@@ -155,8 +155,8 @@ impl DemoApp {
         } else {
             self.ui.label("Register");
             self.ui.text_input("Email", &mut self.register_email, "email@example.com");
-            self.ui.text_input("Password", &mut self.register_password, "password");
-            self.ui.text_input("Confirm Password", &mut self.register_confirm, "confirm");
+            self.ui.text_input_masked("Password", &mut self.register_password, "password");
+            self.ui.text_input_masked("Confirm Password", &mut self.register_confirm, "confirm");
             let roles = vec!["User".to_string(), "Admin".to_string(), "Viewer".to_string()];
             self.ui.select("Role", &roles, &mut self.register_role);
             if self.ui.button("Submit Register") {


### PR DESCRIPTION
## Summary
- New `text_input_masked()` API renders bullet characters (•) instead of actual text
- TextBuffer content unchanged — only the TextRun display text is masked
- One bullet per grapheme cluster for correct cursor positioning
- Demo updated: login and registration forms use masked fields for passwords
- 4 new tests: bullet rendering, value preservation, cursor movement, placeholder display

Closes #10

## Test plan
- [x] `cargo test -p ui-core` — 128 tests pass
- [x] Wasm build compiles
- [ ] Manual: password field shows bullets, form submission returns real text

🤖 Generated with [Claude Code](https://claude.com/claude-code)