### PR TITLE
refactor(ui-wasm): extract WasmRuntime from DemoApp

### DIFF
--- a/crates/ui-core/src/lib.rs
+++ b/crates/ui-core/src/lib.rs
@@ -33,6 +33,7 @@ pub use validation::{ValidationError, ValidationRule};
 /// ```
 pub mod prelude {
     pub use crate::accessibility::{A11yNode, A11yRole, A11yState, A11yTree};
+    pub use crate::app::FormApp;
     pub use crate::batch::{Batch, DrawCmd, Quad, TextRun, Vertex};
     pub use crate::form::{
         FieldId, FieldSchema, FieldType, FieldValue, Form, FormEvent, FormPath, FormSchema,

--- a/crates/ui-wasm/src/demo.rs
+++ b/crates/ui-wasm/src/demo.rs
@@ -1,11 +1,8 @@
-use serde::Serialize;
-use wasm_bindgen::JsValue;
-
-use ui_core::batch::Batch;
-use ui_core::form::{FieldSchema, FieldType, FieldValue, Form, FormEvent, FormPath, FormSchema};
-use ui_core::input::{InputEvent, KeyCode, Modifiers, PointerButton, PointerEvent, TextInputEvent};
+use ui_core::app::FormApp;
+use ui_core::form::{
+    FieldSchema, FieldType, FieldValue, Form, FormEvent, FormPath, FormSchema,
+};
 use ui_core::text::TextBuffer;
-use ui_core::theme::Theme;
 use ui_core::ui::Ui;
 use ui_core::validation::ValidationRule;
 
@@ -32,14 +29,7 @@ struct PendingMock {
     fail: bool,
 }
 
-pub struct FrameOutput {
-    pub batch: Batch,
-    pub a11y_json: JsValue,
-}
-
 pub struct DemoApp {
-    ui: Ui,
-    events: Vec<InputEvent>,
     mode: DemoMode,
     login_email: TextBuffer,
     login_password: TextBuffer,
@@ -56,7 +46,6 @@ pub struct DemoApp {
     nested_form: Form,
     pending: Vec<PendingMock>,
     status: Option<String>,
-    clipboard_request: Option<String>,
     auth_mode: usize,
     register_email: TextBuffer,
     register_password: TextBuffer,
@@ -65,11 +54,8 @@ pub struct DemoApp {
 }
 
 impl DemoApp {
-    pub fn new(width: f32, height: f32) -> Self {
-        let theme = Theme::default_light();
+    pub fn new() -> Self {
         Self {
-            ui: Ui::new(width, height, theme),
-            events: Vec::new(),
             mode: DemoMode::Login,
             login_email: TextBuffer::new(""),
             login_password: TextBuffer::new(""),
@@ -86,7 +72,6 @@ impl DemoApp {
             nested_form: Form::new(nested_schema()),
             pending: Vec::new(),
             status: None,
-            clipboard_request: None,
             auth_mode: 0,
             register_email: TextBuffer::new(""),
             register_password: TextBuffer::new(""),
@@ -95,78 +80,72 @@ impl DemoApp {
         }
     }
 
-    pub fn frame(&mut self, width: f32, height: f32, scale: f32, timestamp_ms: f64) -> FrameOutput {
-        self.resolve_pending(timestamp_ms);
-        let events = std::mem::take(&mut self.events);
-        self.ui.begin_frame(events, width, height, scale, timestamp_ms);
-
-        self.ui.label("GPU Forms UI");
-        if self.ui.button("Login/Register") {
-            self.mode = DemoMode::Login;
-        }
-        if self.ui.button("Dynamic Validation") {
-            self.mode = DemoMode::Dynamic;
-        }
-        if self.ui.button("Nested Groups") {
-            self.mode = DemoMode::Nested;
-        }
-
-        match self.mode {
-            DemoMode::Login => self.build_login(timestamp_ms),
-            DemoMode::Dynamic => self.build_dynamic(timestamp_ms),
-            DemoMode::Nested => self.build_nested(timestamp_ms),
-        }
-
-        if let Some(status) = &self.status {
-            self.ui.label(status);
-        }
-
-        let a11y = self.ui.end_frame();
-        self.clipboard_request = self.ui.take_clipboard_request();
-        let batch = self.ui.take_batch();
-        let serializer =
-            serde_wasm_bindgen::Serializer::new().serialize_large_number_types_as_bigints(true);
-        let a11y_json = a11y.serialize(&serializer).unwrap_or(JsValue::NULL);
-        FrameOutput {
-            batch,
-            a11y_json,
-        }
-    }
-
-    fn build_login(&mut self, timestamp_ms: f64) {
+    fn build_login(&mut self, ui: &mut Ui, timestamp_ms: f64) {
         let options = vec!["Login".to_string(), "Register".to_string()];
-        self.ui.radio_group("Auth Mode", &options, &mut self.auth_mode);
+        ui.radio_group("Auth Mode", &options, &mut self.auth_mode);
         if self.auth_mode == 0 {
-            self.ui.label("Login");
-            self.ui.text_input("Email", &mut self.login_email, "email@example.com");
-            self.ui.text_input_masked("Password", &mut self.login_password, "password");
-            if self.ui.button("Submit Login") {
+            ui.label("Login");
+            ui.text_input("Email", &mut self.login_email, "email@example.com");
+            ui.text_input_masked("Password", &mut self.login_password, "password");
+            if ui.button("Submit Login") {
                 let mut form = self.login_form.clone();
-                let _ = form.set_value(&FormPath(vec!["email".into()]), FieldValue::Text(self.login_email.text().to_string()));
-                let _ = form.set_value(&FormPath(vec!["password".into()]), FieldValue::Text(self.login_password.text().to_string()));
+                let _ = form.set_value(
+                    &FormPath(vec!["email".into()]),
+                    FieldValue::Text(self.login_email.text().to_string()),
+                );
+                let _ = form.set_value(
+                    &FormPath(vec!["password".into()]),
+                    FieldValue::Text(self.login_password.text().to_string()),
+                );
                 self.submit_form(FormKind::Login, &mut form, timestamp_ms);
                 self.login_form = form;
             }
-            self.ui.tooltip("Submit Login", "Sends an optimistic login request with retry/backoff.");
+            ui.tooltip(
+                "Submit Login",
+                "Sends an optimistic login request with retry/backoff.",
+            );
             let errors = Self::collect_errors(&self.login_form);
             let pending = Self::is_pending(&self.login_form);
-            self.show_errors(&errors);
-            self.show_loading(pending);
+            self.show_errors(ui, &errors);
+            self.show_loading(ui, pending);
         } else {
-            self.ui.label("Register");
-            self.ui.text_input("Email", &mut self.register_email, "email@example.com");
-            self.ui.text_input_masked("Password", &mut self.register_password, "password");
-            self.ui.text_input_masked("Confirm Password", &mut self.register_confirm, "confirm");
-            let roles = vec!["User".to_string(), "Admin".to_string(), "Viewer".to_string()];
-            self.ui.select("Role", &roles, &mut self.register_role);
-            if self.ui.button("Submit Register") {
+            ui.label("Register");
+            ui.text_input("Email", &mut self.register_email, "email@example.com");
+            ui.text_input_masked("Password", &mut self.register_password, "password");
+            ui.text_input_masked(
+                "Confirm Password",
+                &mut self.register_confirm,
+                "confirm",
+            );
+            let roles = vec![
+                "User".to_string(),
+                "Admin".to_string(),
+                "Viewer".to_string(),
+            ];
+            ui.select("Role", &roles, &mut self.register_role);
+            if ui.button("Submit Register") {
                 let mut form = self.register_form.clone();
-                let _ = form.set_value(&FormPath(vec!["email".into()]), FieldValue::Text(self.register_email.text().to_string()));
-                let _ = form.set_value(&FormPath(vec!["password".into()]), FieldValue::Text(self.register_password.text().to_string()));
-                let _ = form.set_value(&FormPath(vec!["confirm".into()]), FieldValue::Text(self.register_confirm.text().to_string()));
-                let _ = form.set_value(&FormPath(vec!["role".into()]), FieldValue::Selection(self.register_role.clone()));
+                let _ = form.set_value(
+                    &FormPath(vec!["email".into()]),
+                    FieldValue::Text(self.register_email.text().to_string()),
+                );
+                let _ = form.set_value(
+                    &FormPath(vec!["password".into()]),
+                    FieldValue::Text(self.register_password.text().to_string()),
+                );
+                let _ = form.set_value(
+                    &FormPath(vec!["confirm".into()]),
+                    FieldValue::Text(self.register_confirm.text().to_string()),
+                );
+                let _ = form.set_value(
+                    &FormPath(vec!["role".into()]),
+                    FieldValue::Selection(self.register_role.clone()),
+                );
                 if self.register_password.text() != self.register_confirm.text() {
-                    form.set_field_error(&FormPath(vec!["confirm".into()]), "Passwords do not match.");
+                    form.set_field_error(
+                        &FormPath(vec!["confirm".into()]),
+                        "Passwords do not match.",
+                    );
                 } else {
                     self.submit_form(FormKind::Register, &mut form, timestamp_ms);
                 }
@@ -174,39 +153,51 @@ impl DemoApp {
             }
             let errors = Self::collect_errors(&self.register_form);
             let pending = Self::is_pending(&self.register_form);
-            self.show_errors(&errors);
-            self.show_loading(pending);
+            self.show_errors(ui, &errors);
+            self.show_loading(ui, pending);
         }
     }
 
-    fn build_dynamic(&mut self, timestamp_ms: f64) {
-        self.ui.label("Dynamic Validation");
-        self.ui.text_input("Username", &mut self.dynamic_name, "user");
-        self.ui.text_input("Age", &mut self.dynamic_age, "18");
-        self.ui
-            .text_input_multiline("Bio", &mut self.dynamic_bio, "multi-line bio", 80.0);
-        self.ui.checkbox("Subscribe to updates", &mut self.dynamic_subscribe);
-        if self.ui.button("Submit Profile") {
+    fn build_dynamic(&mut self, ui: &mut Ui, timestamp_ms: f64) {
+        ui.label("Dynamic Validation");
+        ui.text_input("Username", &mut self.dynamic_name, "user");
+        ui.text_input("Age", &mut self.dynamic_age, "18");
+        ui.text_input_multiline("Bio", &mut self.dynamic_bio, "multi-line bio", 80.0);
+        ui.checkbox("Subscribe to updates", &mut self.dynamic_subscribe);
+        if ui.button("Submit Profile") {
             let mut form = self.dynamic_form.clone();
-            let _ = form.set_value(&FormPath(vec!["username".into()]), FieldValue::Text(self.dynamic_name.text().to_string()));
+            let _ = form.set_value(
+                &FormPath(vec!["username".into()]),
+                FieldValue::Text(self.dynamic_name.text().to_string()),
+            );
             let age = self.dynamic_age.text().parse::<f64>().unwrap_or(0.0);
             let _ = form.set_value(&FormPath(vec!["age".into()]), FieldValue::Number(age));
-            let _ = form.set_value(&FormPath(vec!["bio".into()]), FieldValue::Text(self.dynamic_bio.text().to_string()));
-            let _ = form.set_value(&FormPath(vec!["subscribe".into()]), FieldValue::Bool(self.dynamic_subscribe));
+            let _ = form.set_value(
+                &FormPath(vec!["bio".into()]),
+                FieldValue::Text(self.dynamic_bio.text().to_string()),
+            );
+            let _ = form.set_value(
+                &FormPath(vec!["subscribe".into()]),
+                FieldValue::Bool(self.dynamic_subscribe),
+            );
             self.submit_form(FormKind::Dynamic, &mut form, timestamp_ms);
             self.dynamic_form = form;
         }
         let errors = Self::collect_errors(&self.dynamic_form);
         let pending = Self::is_pending(&self.dynamic_form);
-        self.show_errors(&errors);
-        self.show_loading(pending);
+        self.show_errors(ui, &errors);
+        self.show_loading(ui, pending);
     }
 
-    fn build_nested(&mut self, timestamp_ms: f64) {
-        self.ui.label("Nested Groups");
-        self.ui.text_input("Full Name", &mut self.nested_name, "Jane Doe");
-        self.ui.text_input("Contact Email", &mut self.nested_email, "jane@domain.com");
-        if self.ui.button("Add Contact") {
+    fn build_nested(&mut self, ui: &mut Ui, timestamp_ms: f64) {
+        ui.label("Nested Groups");
+        ui.text_input("Full Name", &mut self.nested_name, "Jane Doe");
+        ui.text_input(
+            "Contact Email",
+            &mut self.nested_email,
+            "jane@domain.com",
+        );
+        if ui.button("Add Contact") {
             self.nested_contacts
                 .push((TextBuffer::new(""), TextBuffer::new("")));
             let _ = self.nested_form.add_repeat_group(
@@ -230,31 +221,45 @@ impl DemoApp {
             );
         }
         for (idx, (label, value)) in self.nested_contacts.iter_mut().enumerate() {
-            self.ui.push_id(idx);
-            self.ui.label(&format!("Contact {}", idx + 1));
-            self.ui.text_input("Label", label, "Work");
-            self.ui.text_input("Email", value, "name@domain.com");
+            ui.push_id(idx);
+            ui.label(&format!("Contact {}", idx + 1));
+            ui.text_input("Label", label, "Work");
+            ui.text_input("Email", value, "name@domain.com");
             let _ = self.nested_form.set_value(
-                &FormPath(vec!["contacts".into(), idx.to_string(), "label".into()]),
+                &FormPath(vec![
+                    "contacts".into(),
+                    idx.to_string(),
+                    "label".into(),
+                ]),
                 FieldValue::Text(label.text().to_string()),
             );
             let _ = self.nested_form.set_value(
-                &FormPath(vec!["contacts".into(), idx.to_string(), "value".into()]),
+                &FormPath(vec![
+                    "contacts".into(),
+                    idx.to_string(),
+                    "value".into(),
+                ]),
                 FieldValue::Text(value.text().to_string()),
             );
-            self.ui.pop_id();
+            ui.pop_id();
         }
-        if self.ui.button("Submit Nested") {
+        if ui.button("Submit Nested") {
             let mut form = self.nested_form.clone();
-            let _ = form.set_value(&FormPath(vec!["profile".into(), "name".into()]), FieldValue::Text(self.nested_name.text().to_string()));
-            let _ = form.set_value(&FormPath(vec!["profile".into(), "email".into()]), FieldValue::Text(self.nested_email.text().to_string()));
+            let _ = form.set_value(
+                &FormPath(vec!["profile".into(), "name".into()]),
+                FieldValue::Text(self.nested_name.text().to_string()),
+            );
+            let _ = form.set_value(
+                &FormPath(vec!["profile".into(), "email".into()]),
+                FieldValue::Text(self.nested_email.text().to_string()),
+            );
             self.submit_form(FormKind::Nested, &mut form, timestamp_ms);
             self.nested_form = form;
         }
         let errors = Self::collect_errors(&self.nested_form);
         let pending = Self::is_pending(&self.nested_form);
-        self.show_errors(&errors);
-        self.show_loading(pending);
+        self.show_errors(ui, &errors);
+        self.show_loading(ui, pending);
     }
 
     fn submit_form(&mut self, kind: FormKind, form: &mut Form, timestamp_ms: f64) {
@@ -300,114 +305,6 @@ impl DemoApp {
         self.pending = remaining;
     }
 
-    pub fn take_clipboard_request(&mut self) -> Option<String> {
-        self.clipboard_request.take()
-    }
-
-    /// Set focus to the widget with the given ID.
-    /// Called from the accessibility mirror when the screen reader moves focus.
-    pub fn set_focus(&mut self, id: u64) {
-        self.ui.set_focus_by_id(id);
-    }
-
-    /// Returns the bounding rect (x, y, w, h) of the currently focused widget,
-    /// or `None` if nothing is focused.
-    pub fn focused_widget_rect(&self) -> Option<[f32; 4]> {
-        self.ui.focused_widget_rect().map(|r| [r.x, r.y, r.w, r.h])
-    }
-
-    /// Returns `true` if any widget currently has focus.
-    pub fn has_focused_widget(&self) -> bool {
-        self.ui.focused_id().is_some()
-    }
-
-    /// Returns the kind of the focused widget as a string, or `None`.
-    pub fn focused_widget_kind_str(&self) -> Option<&'static str> {
-        use ui_core::ui::WidgetKind;
-        self.ui.focused_widget_kind().map(|k| match k {
-            WidgetKind::Label => "label",
-            WidgetKind::Button => "button",
-            WidgetKind::Checkbox => "checkbox",
-            WidgetKind::Radio => "radio",
-            WidgetKind::TextInput => "textinput",
-            WidgetKind::Select => "select",
-            WidgetKind::Group => "group",
-            _ => "unknown",
-        })
-    }
-
-    pub fn handle_pointer_down(&mut self, x: f32, y: f32, button: u16, ctrl: bool, alt: bool, shift: bool, meta: bool) {
-        let event = InputEvent::PointerDown(PointerEvent {
-            pos: ui_core::types::Vec2::new(x, y),
-            button: Some(map_button(button)),
-            modifiers: Modifiers { ctrl, alt, shift, meta },
-        });
-        self.events.push(event);
-    }
-
-    pub fn handle_pointer_up(&mut self, x: f32, y: f32, button: u16, ctrl: bool, alt: bool, shift: bool, meta: bool) {
-        let event = InputEvent::PointerUp(PointerEvent {
-            pos: ui_core::types::Vec2::new(x, y),
-            button: Some(map_button(button)),
-            modifiers: Modifiers { ctrl, alt, shift, meta },
-        });
-        self.events.push(event);
-    }
-
-    pub fn handle_pointer_move(&mut self, x: f32, y: f32, ctrl: bool, alt: bool, shift: bool, meta: bool) {
-        let event = InputEvent::PointerMove(PointerEvent {
-            pos: ui_core::types::Vec2::new(x, y),
-            button: None,
-            modifiers: Modifiers { ctrl, alt, shift, meta },
-        });
-        self.events.push(event);
-    }
-
-    pub fn handle_wheel(&mut self, x: f32, y: f32, dx: f32, dy: f32, ctrl: bool, alt: bool, shift: bool, meta: bool) {
-        let event = InputEvent::PointerWheel {
-            pos: ui_core::types::Vec2::new(x, y),
-            delta: ui_core::types::Vec2::new(dx, dy),
-            modifiers: Modifiers { ctrl, alt, shift, meta },
-        };
-        self.events.push(event);
-    }
-
-    pub fn handle_key_down(&mut self, code: &str, ctrl: bool, alt: bool, shift: bool, meta: bool) {
-        let event = InputEvent::KeyDown {
-            code: KeyCode::from_code_str(code),
-            modifiers: Modifiers { ctrl, alt, shift, meta },
-        };
-        self.events.push(event);
-    }
-
-    pub fn handle_key_up(&mut self, code: &str, ctrl: bool, alt: bool, shift: bool, meta: bool) {
-        let event = InputEvent::KeyUp {
-            code: KeyCode::from_code_str(code),
-            modifiers: Modifiers { ctrl, alt, shift, meta },
-        };
-        self.events.push(event);
-    }
-
-    pub fn handle_text_input(&mut self, text: String) {
-        self.events.push(InputEvent::TextInput(TextInputEvent { text }));
-    }
-
-    pub fn handle_composition_start(&mut self) {
-        self.events.push(InputEvent::CompositionStart);
-    }
-
-    pub fn handle_composition_update(&mut self, text: String) {
-        self.events.push(InputEvent::CompositionUpdate(text));
-    }
-
-    pub fn handle_composition_end(&mut self, text: String) {
-        self.events.push(InputEvent::CompositionEnd(text));
-    }
-
-    pub fn handle_paste(&mut self, text: String) {
-        self.events.push(InputEvent::Paste(text));
-    }
-
     fn collect_errors(form: &Form) -> Vec<String> {
         form.state()
             .fields()
@@ -420,30 +317,55 @@ impl DemoApp {
         form.state().fields().values().any(|field| field.pending)
     }
 
-    fn show_errors(&mut self, errors: &[String]) {
+    fn show_errors(&mut self, ui: &mut Ui, errors: &[String]) {
         for error in errors {
-            let color = self.ui.theme().colors.error;
-            self.ui.label_colored(error, color);
+            let color = ui.theme().colors.error;
+            ui.label_colored(error, color);
         }
     }
 
-    fn show_loading(&mut self, pending: bool) {
+    fn show_loading(&mut self, ui: &mut Ui, pending: bool) {
         if pending {
-            let color = self.ui.theme().colors.primary;
-            self.ui.label_colored("Loading...", color);
+            let color = ui.theme().colors.primary;
+            ui.label_colored("Loading...", color);
         }
     }
 }
 
-fn map_button(button: u16) -> PointerButton {
-    match button {
-        0 => PointerButton::Left,
-        1 => PointerButton::Middle,
-        2 => PointerButton::Right,
-        other => PointerButton::Other(other),
+impl FormApp for DemoApp {
+    fn build(&mut self, ui: &mut Ui, _form: &mut Form) {
+        let timestamp_ms = ui.time_ms();
+        self.resolve_pending(timestamp_ms);
+
+        ui.label("GPU Forms UI");
+        if ui.button("Login/Register") {
+            self.mode = DemoMode::Login;
+        }
+        if ui.button("Dynamic Validation") {
+            self.mode = DemoMode::Dynamic;
+        }
+        if ui.button("Nested Groups") {
+            self.mode = DemoMode::Nested;
+        }
+
+        match self.mode {
+            DemoMode::Login => self.build_login(ui, timestamp_ms),
+            DemoMode::Dynamic => self.build_dynamic(ui, timestamp_ms),
+            DemoMode::Nested => self.build_nested(ui, timestamp_ms),
+        }
+
+        if let Some(status) = &self.status {
+            ui.label(status);
+        }
+    }
+
+    fn schema(&self) -> FormSchema {
+        // The DemoApp manages multiple forms internally; we return the
+        // login schema as the "primary" form for the runtime. The other
+        // forms are owned by DemoApp itself.
+        login_schema()
     }
 }
-
 
 fn login_schema() -> FormSchema {
     FormSchema::new("login")

--- a/crates/ui-wasm/src/lib.rs
+++ b/crates/ui-wasm/src/lib.rs
@@ -1,102 +1,85 @@
 mod atlas;
 mod demo;
 mod renderer;
+pub mod runtime;
 
 use demo::DemoApp;
-use renderer::{resolve_text_runs, Renderer};
+use runtime::WasmRuntime;
 use wasm_bindgen::prelude::*;
 use web_sys::HtmlCanvasElement;
 
 #[wasm_bindgen]
 pub struct WasmApp {
-    demo: DemoApp,
-    renderer: Renderer,
-    width: f32,
-    height: f32,
-    scale: f32,
+    runtime: WasmRuntime<DemoApp>,
 }
 
 #[wasm_bindgen]
 impl WasmApp {
     #[wasm_bindgen(constructor)]
     pub fn new(canvas: HtmlCanvasElement, width: f32, height: f32, scale: f32) -> Result<WasmApp, JsValue> {
-        let renderer = Renderer::new(&canvas, width, height)?;
-        Ok(Self {
-            demo: DemoApp::new(width, height),
-            renderer,
-            width,
-            height,
-            scale,
-        })
+        let app = DemoApp::new();
+        let runtime = WasmRuntime::new(&canvas, width, height, scale, app)?;
+        Ok(Self { runtime })
     }
 
     pub fn resize(&mut self, width: f32, height: f32, scale: f32) {
-        self.width = width;
-        self.height = height;
-        self.scale = scale;
-        self.renderer.resize(width, height);
+        self.runtime.resize(width, height, scale);
     }
 
     pub fn set_font_bytes(&mut self, bytes: Vec<u8>) {
-        self.renderer.set_font_bytes(bytes);
+        self.runtime.set_font_bytes(bytes);
     }
 
     pub fn frame(&mut self, timestamp_ms: f64) -> Result<JsValue, JsValue> {
-        let output = self.demo.frame(self.width, self.height, self.scale, timestamp_ms);
-        let mut batch = output.batch;
-        // Resolve text runs into vertex quads (rasterization + quad generation)
-        // BEFORE the render pass, so the renderer receives a complete batch.
-        resolve_text_runs(&mut batch, self.renderer.atlas_mut());
-        self.renderer.render(&batch)?;
-        Ok(output.a11y_json)
+        self.runtime.frame(timestamp_ms)
     }
 
     pub fn handle_pointer_down(&mut self, x: f32, y: f32, button: u16, ctrl: bool, alt: bool, shift: bool, meta: bool) {
-        self.demo.handle_pointer_down(x, y, button, ctrl, alt, shift, meta);
+        self.runtime.handle_pointer_down(x, y, button, ctrl, alt, shift, meta);
     }
 
     pub fn handle_pointer_up(&mut self, x: f32, y: f32, button: u16, ctrl: bool, alt: bool, shift: bool, meta: bool) {
-        self.demo.handle_pointer_up(x, y, button, ctrl, alt, shift, meta);
+        self.runtime.handle_pointer_up(x, y, button, ctrl, alt, shift, meta);
     }
 
     pub fn handle_pointer_move(&mut self, x: f32, y: f32, ctrl: bool, alt: bool, shift: bool, meta: bool) {
-        self.demo.handle_pointer_move(x, y, ctrl, alt, shift, meta);
+        self.runtime.handle_pointer_move(x, y, ctrl, alt, shift, meta);
     }
 
     pub fn handle_wheel(&mut self, x: f32, y: f32, dx: f32, dy: f32, ctrl: bool, alt: bool, shift: bool, meta: bool) {
-        self.demo.handle_wheel(x, y, dx, dy, ctrl, alt, shift, meta);
+        self.runtime.handle_wheel(x, y, dx, dy, ctrl, alt, shift, meta);
     }
 
     pub fn handle_key_down(&mut self, code: &str, ctrl: bool, alt: bool, shift: bool, meta: bool) {
-        self.demo.handle_key_down(code, ctrl, alt, shift, meta);
+        self.runtime.handle_key_down(code, ctrl, alt, shift, meta);
     }
 
     pub fn handle_key_up(&mut self, code: &str, ctrl: bool, alt: bool, shift: bool, meta: bool) {
-        self.demo.handle_key_up(code, ctrl, alt, shift, meta);
+        self.runtime.handle_key_up(code, ctrl, alt, shift, meta);
     }
 
     pub fn handle_text_input(&mut self, text: String) {
-        self.demo.handle_text_input(text);
+        self.runtime.handle_text_input(text);
     }
 
     pub fn handle_composition_start(&mut self) {
-        self.demo.handle_composition_start();
+        self.runtime.handle_composition_start();
     }
 
     pub fn handle_composition_update(&mut self, text: String) {
-        self.demo.handle_composition_update(text);
+        self.runtime.handle_composition_update(text);
     }
 
     pub fn handle_composition_end(&mut self, text: String) {
-        self.demo.handle_composition_end(text);
+        self.runtime.handle_composition_end(text);
     }
 
     pub fn handle_paste(&mut self, text: String) {
-        self.demo.handle_paste(text);
+        self.runtime.handle_paste(text);
     }
 
     pub fn take_clipboard_request(&mut self) -> Option<String> {
-        self.demo.take_clipboard_request()
+        self.runtime.take_clipboard_request()
     }
 
     /// Notify the renderer that the WebGL context has been lost.
@@ -104,7 +87,7 @@ impl WasmApp {
     /// While the context is lost, `frame()` will skip all GPU work but
     /// continue updating application state so no user data is lost.
     pub fn notify_context_lost(&mut self) {
-        self.renderer.notify_context_lost();
+        self.runtime.notify_context_lost();
     }
 
     /// Recreate all GPU resources after a WebGL context restoration.
@@ -112,24 +95,24 @@ impl WasmApp {
     /// Must be called from the `webglcontextrestored` event handler.
     /// Returns an error if resource creation fails.
     pub fn reinitialize_renderer(&mut self) -> Result<(), JsValue> {
-        self.renderer.reinitialize()
+        self.runtime.reinitialize_renderer()
     }
 
     /// Set focus to the widget with the given ID.
     /// Called from the accessibility mirror when the screen reader moves focus.
     pub fn set_focus(&mut self, id: f64) {
-        self.demo.set_focus(id as u64);
+        self.runtime.set_focus(id as u64);
     }
 
     /// Returns `true` if any widget currently has focus.
     pub fn has_focused_widget(&self) -> bool {
-        self.demo.has_focused_widget()
+        self.runtime.has_focused_widget()
     }
 
     /// Returns the kind of the focused widget as a string (e.g. "textinput",
     /// "button"), or `null` if no widget is focused.
     pub fn focused_widget_kind(&self) -> JsValue {
-        match self.demo.focused_widget_kind_str() {
+        match self.runtime.focused_widget_kind_str() {
             Some(kind) => JsValue::from_str(kind),
             None => JsValue::NULL,
         }
@@ -138,7 +121,7 @@ impl WasmApp {
     /// Returns the focused widget's bounding rect as [x, y, w, h] in canvas
     /// pixels, or `null` if no widget is focused.
     pub fn focused_widget_rect(&self) -> JsValue {
-        match self.demo.focused_widget_rect() {
+        match self.runtime.focused_widget_rect() {
             Some([x, y, w, h]) => {
                 let arr = js_sys::Float32Array::new_with_length(4);
                 arr.copy_from(&[x, y, w, h]);
@@ -148,4 +131,3 @@ impl WasmApp {
         }
     }
 }
-

--- a/crates/ui-wasm/src/runtime.rs
+++ b/crates/ui-wasm/src/runtime.rs
@@ -1,0 +1,313 @@
+use serde::Serialize;
+use wasm_bindgen::JsValue;
+use web_sys::HtmlCanvasElement;
+
+use ui_core::app::FormApp;
+use ui_core::form::Form;
+use ui_core::input::{
+    InputEvent, KeyCode, Modifiers, PointerButton, PointerEvent, TextInputEvent,
+};
+use ui_core::theme::Theme;
+use ui_core::types::Vec2;
+use ui_core::ui::{Ui, WidgetKind};
+
+use crate::renderer::{resolve_text_runs, Renderer};
+
+/// A reusable runtime that drives any `FormApp` implementation in the browser.
+///
+/// `WasmRuntime` owns the `Ui`, `Renderer`, `Form`, event queue, and the
+/// application itself. It provides the frame loop, event forwarding,
+/// accessibility tree export, and clipboard request plumbing so that
+/// `FormApp` implementations only need to define *what* to render.
+pub struct WasmRuntime<A: FormApp> {
+    app: A,
+    ui: Ui,
+    renderer: Renderer,
+    form: Form,
+    events: Vec<InputEvent>,
+    width: f32,
+    height: f32,
+    scale: f32,
+    clipboard_request: Option<String>,
+}
+
+impl<A: FormApp> WasmRuntime<A> {
+    /// Create a new runtime for the given `FormApp`.
+    ///
+    /// Initializes the `Ui`, `Renderer`, and `Form` (from `app.schema()`).
+    pub fn new(
+        canvas: &HtmlCanvasElement,
+        width: f32,
+        height: f32,
+        scale: f32,
+        app: A,
+    ) -> Result<Self, JsValue> {
+        let renderer = Renderer::new(canvas, width, height)?;
+        let theme = Theme::default_light();
+        let ui = Ui::new(width, height, theme);
+        let form = Form::new(app.schema());
+        Ok(Self {
+            app,
+            ui,
+            renderer,
+            form,
+            events: Vec::new(),
+            width,
+            height,
+            scale,
+            clipboard_request: None,
+        })
+    }
+
+    /// Run one frame: begin, build UI, end, resolve text, render.
+    ///
+    /// Returns the accessibility tree as a `JsValue` for the a11y mirror.
+    pub fn frame(&mut self, timestamp_ms: f64) -> Result<JsValue, JsValue> {
+        let events = std::mem::take(&mut self.events);
+        self.ui
+            .begin_frame(events, self.width, self.height, self.scale, timestamp_ms);
+
+        self.app.build(&mut self.ui, &mut self.form);
+
+        let a11y = self.ui.end_frame();
+        self.clipboard_request = self.ui.take_clipboard_request();
+        let mut batch = self.ui.take_batch();
+
+        // Resolve text runs into vertex quads (rasterization + quad generation)
+        // BEFORE the render pass, so the renderer receives a complete batch.
+        resolve_text_runs(&mut batch, self.renderer.atlas_mut());
+        self.renderer.render(&batch)?;
+
+        let serializer =
+            serde_wasm_bindgen::Serializer::new().serialize_large_number_types_as_bigints(true);
+        let a11y_json = a11y.serialize(&serializer).unwrap_or(JsValue::NULL);
+        Ok(a11y_json)
+    }
+
+    /// Resize the renderer and update stored dimensions.
+    pub fn resize(&mut self, width: f32, height: f32, scale: f32) {
+        self.width = width;
+        self.height = height;
+        self.scale = scale;
+        self.renderer.resize(width, height);
+    }
+
+    /// Forward a font to the renderer's text atlas.
+    pub fn set_font_bytes(&mut self, bytes: Vec<u8>) {
+        self.renderer.set_font_bytes(bytes);
+    }
+
+    // -----------------------------------------------------------------
+    // Event forwarding
+    // -----------------------------------------------------------------
+
+    pub fn handle_pointer_down(
+        &mut self,
+        x: f32,
+        y: f32,
+        button: u16,
+        ctrl: bool,
+        alt: bool,
+        shift: bool,
+        meta: bool,
+    ) {
+        self.events.push(InputEvent::PointerDown(PointerEvent {
+            pos: Vec2::new(x, y),
+            button: Some(map_button(button)),
+            modifiers: Modifiers {
+                ctrl,
+                alt,
+                shift,
+                meta,
+            },
+        }));
+    }
+
+    pub fn handle_pointer_up(
+        &mut self,
+        x: f32,
+        y: f32,
+        button: u16,
+        ctrl: bool,
+        alt: bool,
+        shift: bool,
+        meta: bool,
+    ) {
+        self.events.push(InputEvent::PointerUp(PointerEvent {
+            pos: Vec2::new(x, y),
+            button: Some(map_button(button)),
+            modifiers: Modifiers {
+                ctrl,
+                alt,
+                shift,
+                meta,
+            },
+        }));
+    }
+
+    pub fn handle_pointer_move(
+        &mut self,
+        x: f32,
+        y: f32,
+        ctrl: bool,
+        alt: bool,
+        shift: bool,
+        meta: bool,
+    ) {
+        self.events.push(InputEvent::PointerMove(PointerEvent {
+            pos: Vec2::new(x, y),
+            button: None,
+            modifiers: Modifiers {
+                ctrl,
+                alt,
+                shift,
+                meta,
+            },
+        }));
+    }
+
+    pub fn handle_wheel(
+        &mut self,
+        x: f32,
+        y: f32,
+        dx: f32,
+        dy: f32,
+        ctrl: bool,
+        alt: bool,
+        shift: bool,
+        meta: bool,
+    ) {
+        self.events.push(InputEvent::PointerWheel {
+            pos: Vec2::new(x, y),
+            delta: Vec2::new(dx, dy),
+            modifiers: Modifiers {
+                ctrl,
+                alt,
+                shift,
+                meta,
+            },
+        });
+    }
+
+    pub fn handle_key_down(
+        &mut self,
+        code: &str,
+        ctrl: bool,
+        alt: bool,
+        shift: bool,
+        meta: bool,
+    ) {
+        self.events.push(InputEvent::KeyDown {
+            code: KeyCode::from_code_str(code),
+            modifiers: Modifiers {
+                ctrl,
+                alt,
+                shift,
+                meta,
+            },
+        });
+    }
+
+    pub fn handle_key_up(
+        &mut self,
+        code: &str,
+        ctrl: bool,
+        alt: bool,
+        shift: bool,
+        meta: bool,
+    ) {
+        self.events.push(InputEvent::KeyUp {
+            code: KeyCode::from_code_str(code),
+            modifiers: Modifiers {
+                ctrl,
+                alt,
+                shift,
+                meta,
+            },
+        });
+    }
+
+    pub fn handle_text_input(&mut self, text: String) {
+        self.events
+            .push(InputEvent::TextInput(TextInputEvent { text }));
+    }
+
+    pub fn handle_composition_start(&mut self) {
+        self.events.push(InputEvent::CompositionStart);
+    }
+
+    pub fn handle_composition_update(&mut self, text: String) {
+        self.events.push(InputEvent::CompositionUpdate(text));
+    }
+
+    pub fn handle_composition_end(&mut self, text: String) {
+        self.events.push(InputEvent::CompositionEnd(text));
+    }
+
+    pub fn handle_paste(&mut self, text: String) {
+        self.events.push(InputEvent::Paste(text));
+    }
+
+    // -----------------------------------------------------------------
+    // Focus & accessibility queries
+    // -----------------------------------------------------------------
+
+    /// Set focus to the widget with the given ID.
+    pub fn set_focus(&mut self, id: u64) {
+        self.ui.set_focus_by_id(id);
+    }
+
+    /// Returns `true` if any widget currently has focus.
+    pub fn has_focused_widget(&self) -> bool {
+        self.ui.focused_id().is_some()
+    }
+
+    /// Returns the kind of the focused widget as a string, or `None`.
+    pub fn focused_widget_kind_str(&self) -> Option<&'static str> {
+        self.ui.focused_widget_kind().map(|k| match k {
+            WidgetKind::Label => "label",
+            WidgetKind::Button => "button",
+            WidgetKind::Checkbox => "checkbox",
+            WidgetKind::Radio => "radio",
+            WidgetKind::TextInput => "textinput",
+            WidgetKind::Select => "select",
+            WidgetKind::Group => "group",
+            _ => "unknown",
+        })
+    }
+
+    /// Returns the bounding rect [x, y, w, h] of the focused widget, or `None`.
+    pub fn focused_widget_rect(&self) -> Option<[f32; 4]> {
+        self.ui
+            .focused_widget_rect()
+            .map(|r| [r.x, r.y, r.w, r.h])
+    }
+
+    /// Take the clipboard request, if any.
+    pub fn take_clipboard_request(&mut self) -> Option<String> {
+        self.clipboard_request.take()
+    }
+
+    // -----------------------------------------------------------------
+    // Context loss
+    // -----------------------------------------------------------------
+
+    /// Notify the renderer that the WebGL context has been lost.
+    pub fn notify_context_lost(&mut self) {
+        self.renderer.notify_context_lost();
+    }
+
+    /// Recreate all GPU resources after a WebGL context restoration.
+    pub fn reinitialize_renderer(&mut self) -> Result<(), JsValue> {
+        self.renderer.reinitialize()
+    }
+}
+
+fn map_button(button: u16) -> PointerButton {
+    match button {
+        0 => PointerButton::Left,
+        1 => PointerButton::Middle,
+        2 => PointerButton::Right,
+        other => PointerButton::Other(other),
+    }
+}


### PR DESCRIPTION
## Summary
- New `WasmRuntime<A: FormApp>` in `crates/ui-wasm/src/runtime.rs`
- Owns Ui, Renderer, Form, event queue — handles frame loop, events, a11y, clipboard, resize
- DemoApp simplified to `FormApp` impl (build + schema only)
- WasmApp wraps `WasmRuntime<DemoApp>`, all wasm_bindgen methods delegate
- Any `FormApp` impl can now run on the web without forking the demo

Closes #69

## Test plan
- [x] `cargo test -p ui-core` — 132 tests pass
- [x] `cargo build -p ui-wasm --target wasm32-unknown-unknown` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)