### PR TITLE
fix(ui-wasm): key glyph cache on (char, quantized_font_size)

### DIFF
--- a/crates/ui-wasm/src/atlas.rs
+++ b/crates/ui-wasm/src/atlas.rs
@@ -4,6 +4,13 @@ use fontdue::Font;
 
 use ui_core::types::{Rect, Vec2};
 
+/// Quantize a font size to 2px buckets to limit glyph cache explosion.
+/// For example, 11px and 12px map to the same bucket (12), while 13px maps
+/// to a different bucket (14).
+pub fn quantize_font_size(font_size: f32) -> u16 {
+    ((font_size / 2.0).round() as u16) * 2
+}
+
 #[derive(Clone, Debug)]
 pub struct Glyph {
     pub uv: Rect,
@@ -19,7 +26,7 @@ pub struct TextAtlas {
     pixels: Vec<u8>,
     cursor: Vec2,
     row_h: f32,
-    glyphs: HashMap<char, Glyph>,
+    glyphs: HashMap<(char, u16), Glyph>,
     dirty: bool,
     font: Option<Font>,
     generation: u64,
@@ -71,20 +78,26 @@ impl TextAtlas {
         }
     }
 
-    /// Look up a previously cached glyph. Returns `None` if the glyph has not
-    /// been rasterized yet (callers on the render path should treat this as a
-    /// bug — layout should have pre-populated the atlas).
-    pub fn get_cached_glyph(&self, ch: char) -> Option<&Glyph> {
-        self.glyphs.get(&ch)
+    /// Look up a previously cached glyph at a specific font size. Returns
+    /// `None` if the glyph has not been rasterized yet at that quantized size
+    /// (callers on the render path should treat this as a bug — layout should
+    /// have pre-populated the atlas).
+    pub fn get_cached_glyph(&self, ch: char, font_size: f32) -> Option<&Glyph> {
+        let key = (ch, quantize_font_size(font_size));
+        self.glyphs.get(&key)
     }
 
     pub fn ensure_glyph(&mut self, ch: char, font_size: f32) -> Glyph {
-        if let Some(glyph) = self.glyphs.get(&ch) {
+        let quantized = quantize_font_size(font_size);
+        let key = (ch, quantized);
+        if let Some(glyph) = self.glyphs.get(&key) {
             return glyph.clone();
         }
 
+        // Rasterize at the quantized size for consistent cache behavior.
+        let raster_size = quantized as f32;
         let glyph = if let Some(font) = &self.font {
-            let (metrics, bitmap) = font.rasterize(ch, font_size);
+            let (metrics, bitmap) = font.rasterize(ch, raster_size);
             let w = metrics.width as u32;
             let h = metrics.height as u32;
             let (x, y) = self.allocate(w.max(1), h.max(1));
@@ -115,7 +128,7 @@ impl TextAtlas {
             }
         };
 
-        self.glyphs.insert(ch, glyph.clone());
+        self.glyphs.insert(key, glyph.clone());
         glyph
     }
 
@@ -179,5 +192,69 @@ impl TextAtlas {
         self.row_h = self.row_h.max(h as f32);
         self.dirty = true;
         (x, y)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quantize_font_size_2px_buckets() {
+        // 11px and 12px both round to 12
+        assert_eq!(quantize_font_size(11.0), 12);
+        assert_eq!(quantize_font_size(12.0), 12);
+        // 13px rounds to 14
+        assert_eq!(quantize_font_size(13.0), 14);
+        // 16px stays 16
+        assert_eq!(quantize_font_size(16.0), 16);
+        // 24px stays 24
+        assert_eq!(quantize_font_size(24.0), 24);
+    }
+
+    #[test]
+    fn same_char_different_sizes_produces_different_cache_entries() {
+        let mut atlas = TextAtlas::new(256, 256);
+        // Without a font, ensure_glyph returns fallback glyphs, but the
+        // cache keys should still be distinct.
+        let _g12 = atlas.ensure_glyph('A', 12.0);
+        let _g24 = atlas.ensure_glyph('A', 24.0);
+
+        // Both should be independently retrievable.
+        assert!(atlas.get_cached_glyph('A', 12.0).is_some());
+        assert!(atlas.get_cached_glyph('A', 24.0).is_some());
+
+        // The cache should contain two entries (quantized 12 and 24).
+        assert_eq!(atlas.glyphs.len(), 2);
+    }
+
+    #[test]
+    fn quantized_sizes_share_cache_entry() {
+        let mut atlas = TextAtlas::new(256, 256);
+        let g11 = atlas.ensure_glyph('B', 11.0);
+        let g12 = atlas.ensure_glyph('B', 12.0);
+
+        // 11px and 12px quantize to the same bucket (12), so they should
+        // return the same cached glyph and only one entry should exist.
+        assert_eq!(atlas.glyphs.len(), 1);
+        assert_eq!(g11.advance, g12.advance);
+    }
+
+    #[test]
+    fn cache_lookup_miss_returns_none() {
+        let atlas = TextAtlas::new(256, 256);
+        // No glyphs cached yet — lookup should return None.
+        assert!(atlas.get_cached_glyph('Z', 16.0).is_none());
+    }
+
+    #[test]
+    fn ensure_glyphs_cached_populates_all_chars() {
+        let mut atlas = TextAtlas::new(256, 256);
+        atlas.ensure_glyphs_cached("AB", 16.0);
+
+        assert!(atlas.get_cached_glyph('A', 16.0).is_some());
+        assert!(atlas.get_cached_glyph('B', 16.0).is_some());
+        // Different size should miss.
+        assert!(atlas.get_cached_glyph('A', 24.0).is_none());
     }
 }

--- a/crates/ui-wasm/src/renderer.rs
+++ b/crates/ui-wasm/src/renderer.rs
@@ -292,7 +292,7 @@ pub fn resolve_text_runs(batch: &mut Batch, atlas: &mut TextAtlas) {
                 continue;
             }
             // Glyph is guaranteed to be cached from the first pass.
-            let glyph = atlas.get_cached_glyph(ch).cloned().unwrap_or_else(|| {
+            let glyph = atlas.get_cached_glyph(ch, font_size).cloned().unwrap_or_else(|| {
                 // Fallback: rasterize on demand (should not happen).
                 atlas.ensure_glyph(ch, font_size)
             });


### PR DESCRIPTION
## Summary
- Glyph cache key changed from `char` to `(char, u16)` where u16 is font size quantized to 2px buckets
- Same char at different sizes now rasterizes and caches independently
- `get_cached_glyph()` now takes `font_size` parameter
- 5 new tests covering quantization, multi-size caching, bucket sharing

Closes #9

## Test plan
- [x] Wasm build compiles
- [x] Atlas tests pass
- [ ] Manual: heading at 24px + label at 12px render correctly together

🤖 Generated with [Claude Code](https://claude.com/claude-code)