### PR TITLE
perf(ui-wasm): optimize binary size with wasm-opt and release profile tuning (closes #73)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -91,10 +91,10 @@ jobs:
           echo "Raw size: ${RAW_KB} KB (${RAW_SIZE} bytes)"
           echo "Gzipped size: ${GZIP_KB} KB (${GZIP_SIZE} bytes)"
 
-          MAX_GZIP_BYTES=563200  # 550 KB
+          MAX_GZIP_BYTES=460800  # 450 KB
           if [ "$GZIP_SIZE" -gt "$MAX_GZIP_BYTES" ]; then
-            echo "FAIL: Gzipped WASM binary (${GZIP_KB} KB) exceeds 500 KB limit"
+            echo "FAIL: Gzipped WASM binary (${GZIP_KB} KB) exceeds 450 KB limit"
             exit 1
           else
-            echo "PASS: Gzipped WASM binary (${GZIP_KB} KB) is within 500 KB limit"
+            echo "PASS: Gzipped WASM binary (${GZIP_KB} KB) is within 450 KB limit"
           fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,9 @@ members = [
   "crates/ui-wasm",
   "crates/cdp-runner",
 ]
+
+[profile.release]
+opt-level = "z"
+lto = true
+codegen-units = 1
+strip = true

--- a/crates/ui-wasm/Cargo.toml
+++ b/crates/ui-wasm/Cargo.toml
@@ -25,3 +25,6 @@ serde-wasm-bindgen = "0.6"
 serde_json = "1.0"
 fontdue = "0.8"
 thiserror = "1.0"
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-Oz", "--enable-bulk-memory", "--enable-nontrapping-float-to-int"]


### PR DESCRIPTION
## Summary

- Add `[profile.release]` settings to workspace `Cargo.toml`: `opt-level = "z"`, `lto = true`, `codegen-units = 1`, `strip = true`
- Add `[package.metadata.wasm-pack.profile.release]` to `crates/ui-wasm/Cargo.toml` with `wasm-opt = ["-Oz", "--enable-bulk-memory", "--enable-nontrapping-float-to-int"]`
- Update CI size gate in `.github/workflows/bench.yml` from 550 KB to 450 KB

## Size before/after

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Raw | 1455 KB | 1123 KB | -332 KB (-22.8%) |
| Gzipped | 525 KB | 434 KB | -91 KB (-17.3%) |

We were previously at 525 KB gzipped (above the 500 KB original target, within the bumped 550 KB CI limit). With these changes we're at **434 KB gzipped**, comfortably under 450 KB.

## Size contributors (profiled before optimization)

The main contributors to binary size are:
- **fontdue** — glyph rasterization library (largest single dependency, unavoidable for text rendering)
- **regex** — used in `ui-core` for validation rules (significant size, but core functionality)
- **serde + serde_json** — form payload serialization (needed for form submission API)
- **wasm-bindgen glue** — JS interop scaffolding

The `opt-level = "z"` + LTO combination was the most impactful change as it enables cross-crate dead code elimination during link time, shrinking the binary by eliminating unused generics and monomorphizations across all crates.

## Notes on wasm-opt flags

The binary uses WASM extensions enabled by the Rust compiler by default:
- `--enable-bulk-memory`: required for `memory.copy` / `memory.fill` instructions (generated by Rust for struct copies/initialization)
- `--enable-nontrapping-float-to-int`: required for `trunc_sat` instructions (safe float-to-int conversions used by fontdue and layout math)

## Test plan

- [x] `cargo test -p ui-core` passes
- [x] `cargo check -p ui-wasm --target wasm32-unknown-unknown` passes
- [x] `wasm-pack build` succeeds with wasm-opt pass completing cleanly
- [x] Gzipped output (434 KB) is under both the 450 KB CI threshold and the 500 KB original target

🤖 Generated with [Claude Code](https://claude.com/claude-code)