### PR TITLE
feat(web): autofill and password manager integration via hidden DOM inputs (closes #31)

### DIFF
--- a/crates/ui-core/src/form.rs
+++ b/crates/ui-core/src/form.rs
@@ -80,6 +80,64 @@ impl FieldState {
     }
 }
 
+/// Hint for the browser's autofill / password-manager machinery.
+///
+/// Maps to the HTML `autocomplete` attribute values that password managers and
+/// browser autofill use to identify credential fields.  Only fields that carry
+/// one of these hints will get a corresponding hidden DOM `<input>` in the
+/// `AutofillBridge` on the JS side.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AutocompleteHint {
+    /// `autocomplete="username"` — login username or user identifier.
+    Username,
+    /// `autocomplete="email"` — email address used as a login identifier or
+    /// contact address.
+    Email,
+    /// `autocomplete="current-password"` — password for the current account
+    /// (login form).
+    CurrentPassword,
+    /// `autocomplete="new-password"` — new password chosen by the user
+    /// (registration / change-password form).
+    NewPassword,
+    /// `autocomplete="name"` — full name.
+    Name,
+    /// `autocomplete="given-name"` — given (first) name.
+    GivenName,
+    /// `autocomplete="family-name"` — family (last) name.
+    FamilyName,
+    /// An explicit, arbitrary `autocomplete` token.  Use this for tokens not
+    /// covered by the enum variants above.
+    Custom(String),
+}
+
+impl AutocompleteHint {
+    /// Returns the `autocomplete` attribute string for this hint.
+    pub fn as_str(&self) -> &str {
+        match self {
+            AutocompleteHint::Username => "username",
+            AutocompleteHint::Email => "email",
+            AutocompleteHint::CurrentPassword => "current-password",
+            AutocompleteHint::NewPassword => "new-password",
+            AutocompleteHint::Name => "name",
+            AutocompleteHint::GivenName => "given-name",
+            AutocompleteHint::FamilyName => "family-name",
+            AutocompleteHint::Custom(s) => s.as_str(),
+        }
+    }
+
+    /// Returns the HTML `<input type>` most appropriate for this hint.
+    ///
+    /// Password hints → `"password"`, email hint → `"email"`, everything else
+    /// → `"text"`.
+    pub fn input_type(&self) -> &'static str {
+        match self {
+            AutocompleteHint::CurrentPassword | AutocompleteHint::NewPassword => "password",
+            AutocompleteHint::Email => "email",
+            _ => "text",
+        }
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum FieldType {
     Text,
@@ -96,6 +154,10 @@ pub struct FieldSchema {
     pub field_type: FieldType,
     pub rules: Vec<ValidationRule>,
     pub placeholder: Option<String>,
+    /// Autofill / password-manager hint.  When `Some`, a hidden DOM `<input>`
+    /// with the corresponding `autocomplete` attribute will be created by the
+    /// `AutofillBridge` in `app.js`.
+    pub autocomplete: Option<AutocompleteHint>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -121,7 +183,30 @@ impl FormSchema {
             field_type,
             rules: Vec::new(),
             placeholder: None,
+            autocomplete: None,
         });
+        self
+    }
+
+    /// Set the autofill / password-manager hint for the named field.
+    ///
+    /// When set, the JS `AutofillBridge` will create a hidden `<input>` with
+    /// the matching `autocomplete` attribute so that browser autofill and
+    /// third-party password managers can discover and fill the field.
+    ///
+    /// # Example
+    /// ```
+    /// use ui_core::form::{FormSchema, FieldType, AutocompleteHint};
+    /// let schema = FormSchema::new("login")
+    ///     .field("email", FieldType::Text)
+    ///     .with_autocomplete("email", AutocompleteHint::Email)
+    ///     .field("password", FieldType::Text)
+    ///     .with_autocomplete("password", AutocompleteHint::CurrentPassword);
+    /// ```
+    pub fn with_autocomplete(mut self, name: &str, hint: AutocompleteHint) -> Self {
+        if let Some(field) = self.fields.iter_mut().find(|f| f.id == name) {
+            field.autocomplete = Some(hint);
+        }
         self
     }
 
@@ -171,6 +256,7 @@ impl FormSchema {
             },
             rules: Vec::new(),
             placeholder: None,
+            autocomplete: None,
         });
         self
     }
@@ -187,6 +273,7 @@ impl FormSchema {
             },
             rules: Vec::new(),
             placeholder: None,
+            autocomplete: None,
         });
         self
     }
@@ -646,6 +733,7 @@ mod tests {
             field_type: FieldType::Text,
             rules: vec![],
             placeholder: None,
+            autocomplete: None,
         }
     }
 
@@ -730,6 +818,7 @@ mod tests {
                 field_type: FieldType::Text,
                 rules: vec![ValidationRule::Required],
                 placeholder: None,
+                autocomplete: None,
             }],
         };
         let mut form = Form::new(schema);
@@ -881,6 +970,7 @@ mod tests {
                 field_type: FieldType::Text,
                 rules: vec![ValidationRule::Required],
                 placeholder: None,
+                autocomplete: None,
             }],
         };
         let mut form = Form::new(schema);
@@ -898,6 +988,7 @@ mod tests {
                 field_type: FieldType::Text,
                 rules: vec![ValidationRule::Required],
                 placeholder: None,
+                autocomplete: None,
             }],
         };
         let mut form = Form::new(schema);
@@ -917,6 +1008,7 @@ mod tests {
                 field_type: FieldType::Text,
                 rules: vec![ValidationRule::Required],
                 placeholder: None,
+                autocomplete: None,
             }],
         };
         let mut form = Form::new(schema);
@@ -964,6 +1056,7 @@ mod tests {
                 field_type: FieldType::Text,
                 rules: vec![ValidationRule::Required],
                 placeholder: None,
+                autocomplete: None,
             }],
         };
         let mut form = Form::new(schema);
@@ -1051,6 +1144,7 @@ mod tests {
                     field_type: FieldType::Text,
                     rules: vec![],
                     placeholder: None,
+                    autocomplete: None,
                 },
                 FieldSchema {
                     id: "age".into(),
@@ -1058,6 +1152,7 @@ mod tests {
                     field_type: FieldType::Number,
                     rules: vec![],
                     placeholder: None,
+                    autocomplete: None,
                 },
                 FieldSchema {
                     id: "agree".into(),
@@ -1065,6 +1160,7 @@ mod tests {
                     field_type: FieldType::Checkbox,
                     rules: vec![],
                     placeholder: None,
+                    autocomplete: None,
                 },
             ],
         };
@@ -1299,5 +1395,64 @@ mod tests {
         let pwd_path = FormPath::root().push("password");
         assert!(form.state().get_field(&email_path).is_some());
         assert!(form.state().get_field(&pwd_path).is_some());
+    }
+
+    // -----------------------------------------------------------------------
+    // AutocompleteHint
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn autocomplete_hint_as_str() {
+        assert_eq!(AutocompleteHint::Email.as_str(), "email");
+        assert_eq!(AutocompleteHint::CurrentPassword.as_str(), "current-password");
+        assert_eq!(AutocompleteHint::NewPassword.as_str(), "new-password");
+        assert_eq!(AutocompleteHint::Username.as_str(), "username");
+        assert_eq!(AutocompleteHint::Name.as_str(), "name");
+        assert_eq!(AutocompleteHint::GivenName.as_str(), "given-name");
+        assert_eq!(AutocompleteHint::FamilyName.as_str(), "family-name");
+        assert_eq!(AutocompleteHint::Custom("cc-number".into()).as_str(), "cc-number");
+    }
+
+    #[test]
+    fn autocomplete_hint_input_type() {
+        assert_eq!(AutocompleteHint::CurrentPassword.input_type(), "password");
+        assert_eq!(AutocompleteHint::NewPassword.input_type(), "password");
+        assert_eq!(AutocompleteHint::Email.input_type(), "email");
+        assert_eq!(AutocompleteHint::Username.input_type(), "text");
+        assert_eq!(AutocompleteHint::Name.input_type(), "text");
+    }
+
+    #[test]
+    fn builder_with_autocomplete_sets_hint() {
+        let schema = FormSchema::new("login")
+            .field("email", FieldType::Text)
+            .with_autocomplete("email", AutocompleteHint::Email)
+            .field("password", FieldType::Text)
+            .with_autocomplete("password", AutocompleteHint::CurrentPassword);
+
+        let email = schema.fields.iter().find(|f| f.id == "email").unwrap();
+        let password = schema.fields.iter().find(|f| f.id == "password").unwrap();
+
+        assert_eq!(email.autocomplete, Some(AutocompleteHint::Email));
+        assert_eq!(password.autocomplete, Some(AutocompleteHint::CurrentPassword));
+    }
+
+    #[test]
+    fn builder_with_autocomplete_nonexistent_field_is_noop() {
+        let schema = FormSchema::new("test")
+            .field("email", FieldType::Text)
+            .with_autocomplete("nonexistent", AutocompleteHint::Email);
+
+        // "email" should have no autocomplete set since we referenced a non-existent field
+        let email = schema.fields.iter().find(|f| f.id == "email").unwrap();
+        assert_eq!(email.autocomplete, None);
+    }
+
+    #[test]
+    fn field_without_autocomplete_hint_defaults_to_none() {
+        let schema = FormSchema::new("test")
+            .field("username", FieldType::Text);
+        let field = schema.fields.iter().find(|f| f.id == "username").unwrap();
+        assert_eq!(field.autocomplete, None);
     }
 }

--- a/crates/ui-core/src/lib.rs
+++ b/crates/ui-core/src/lib.rs
@@ -17,8 +17,8 @@ pub use app::FormApp;
 pub use batch::{Batch, DrawCmd, Material, Quad, TextRun, Vertex};
 pub use icon::{IconEntry, IconId, IconPack};
 pub use form::{
-    FieldId, FieldSchema, FieldState, FieldType, FieldValue, Form, FormEvent, FormPath, FormSchema,
-    FormState, PendingSubmission,
+    AutocompleteHint, FieldId, FieldSchema, FieldState, FieldType, FieldValue, Form, FormEvent,
+    FormPath, FormSchema, FormState, PendingSubmission,
 };
 pub use input::{InputEvent, KeyCode, Modifiers, PointerButton, PointerEvent, TextInputEvent};
 pub use state::History;
@@ -39,7 +39,8 @@ pub mod prelude {
     pub use crate::batch::{Batch, DrawCmd, Quad, TextRun, Vertex};
     pub use crate::icon::{IconId, IconPack};
     pub use crate::form::{
-        FieldId, FieldSchema, FieldType, FieldValue, Form, FormEvent, FormPath, FormSchema,
+        AutocompleteHint, FieldId, FieldSchema, FieldType, FieldValue, Form, FormEvent, FormPath,
+        FormSchema,
     };
     pub use crate::input::{InputEvent, KeyCode, Modifiers};
     pub use crate::text::TextBuffer;

--- a/crates/ui-core/tests/optimistic.rs
+++ b/crates/ui-core/tests/optimistic.rs
@@ -11,6 +11,7 @@ fn optimistic_submit_and_rollback() {
             field_type: FieldType::Text,
             rules: vec![ValidationRule::Required],
             placeholder: None,
+            autocomplete: None,
         }],
     };
     let mut form = Form::new(schema);

--- a/crates/ui-core/tests/validation.rs
+++ b/crates/ui-core/tests/validation.rs
@@ -11,6 +11,7 @@ fn required_and_email_validation() {
             field_type: FieldType::Text,
             rules: vec![ValidationRule::Required, ValidationRule::Email],
             placeholder: None,
+            autocomplete: None,
         }],
     };
     let mut form = Form::new(schema);

--- a/crates/ui-wasm/src/demo.rs
+++ b/crates/ui-wasm/src/demo.rs
@@ -1,6 +1,6 @@
 use ui_core::app::FormApp;
 use ui_core::form::{
-    FieldSchema, FieldType, FieldValue, Form, FormEvent, FormPath, FormSchema,
+    AutocompleteHint, FieldSchema, FieldType, FieldValue, Form, FormEvent, FormPath, FormSchema,
 };
 use ui_core::text::TextBuffer;
 use ui_core::ui::Ui;
@@ -209,6 +209,7 @@ impl DemoApp {
                         field_type: FieldType::Text,
                         rules: vec![ValidationRule::Required],
                         placeholder: None,
+                        autocomplete: None,
                     },
                     FieldSchema {
                         id: "value".into(),
@@ -216,6 +217,7 @@ impl DemoApp {
                         field_type: FieldType::Text,
                         rules: vec![ValidationRule::Email],
                         placeholder: None,
+                        autocomplete: None,
                     },
                 ],
             );
@@ -373,9 +375,11 @@ fn login_schema() -> FormSchema {
         .with_label("email", "Email")
         .required("email")
         .with_validation("email", ValidationRule::Email)
+        .with_autocomplete("email", AutocompleteHint::Email)
         .field("password", FieldType::Text)
         .with_label("password", "Password")
         .required("password")
+        .with_autocomplete("password", AutocompleteHint::CurrentPassword)
 }
 
 fn register_schema() -> FormSchema {
@@ -384,12 +388,15 @@ fn register_schema() -> FormSchema {
         .with_label("email", "Email")
         .required("email")
         .with_validation("email", ValidationRule::Email)
+        .with_autocomplete("email", AutocompleteHint::Email)
         .field("password", FieldType::Text)
         .with_label("password", "Password")
         .required("password")
+        .with_autocomplete("password", AutocompleteHint::NewPassword)
         .field("confirm", FieldType::Text)
         .with_label("confirm", "Confirm Password")
         .required("confirm")
+        .with_autocomplete("confirm", AutocompleteHint::NewPassword)
         .field("role", FieldType::Select {
             options: vec!["User".into(), "Admin".into(), "Viewer".into()],
         })

--- a/crates/ui-wasm/src/lib.rs
+++ b/crates/ui-wasm/src/lib.rs
@@ -214,4 +214,37 @@ impl WasmApp {
             None => JsValue::NULL,
         }
     }
+
+    // -----------------------------------------------------------------
+    // Autofill / password-manager bridge
+    // -----------------------------------------------------------------
+
+    /// Return the current text value of the form field at `field_id` (a
+    /// dot-separated path string such as `"email"` or `"profile.name"`).
+    ///
+    /// Returns an empty string when the path does not exist or when the field
+    /// is not a text field.
+    pub fn get_field_value(&self, field_id: &str) -> String {
+        self.runtime.get_field_value(field_id)
+    }
+
+    /// Set the text value of the form field at `field_id`.
+    ///
+    /// This is called by the `AutofillBridge` when the browser autofill or a
+    /// password manager fills a hidden DOM `<input>`, forwarding the value into
+    /// the WASM form model.  Non-existent paths and non-text fields are silently
+    /// ignored.
+    pub fn set_field_value(&mut self, field_id: &str, value: &str) {
+        self.runtime.set_field_value(field_id, value);
+    }
+
+    /// Return a JS array of `{ id, autocomplete, type }` objects describing
+    /// all form fields that carry an autofill hint.
+    ///
+    /// The `AutofillBridge` calls this once at init time to know which hidden
+    /// `<input>` elements to create so that browser autofill and third-party
+    /// password managers can discover and fill the fields.
+    pub fn list_autofill_fields(&self) -> JsValue {
+        self.runtime.list_autofill_fields()
+    }
 }

--- a/crates/ui-wasm/src/runtime.rs
+++ b/crates/ui-wasm/src/runtime.rs
@@ -399,6 +399,110 @@ impl<A: FormApp> WasmRuntime<A> {
     }
 
     // -----------------------------------------------------------------
+    // Autofill / password-manager bridge
+    // -----------------------------------------------------------------
+
+    /// Return the current text value of a form field identified by its dot-path
+    /// string (e.g. `"email"` or `"profile.name"`).
+    ///
+    /// Returns an empty string when the path does not exist or when the field
+    /// holds a non-text value (booleans, numbers, selections, groups).
+    ///
+    /// Called by the JS `AutofillBridge` when it needs to sync the current
+    /// WASM-side value back to a hidden DOM `<input>` after a programmatic
+    /// field update (e.g. to trigger the browser's save-password prompt).
+    pub fn get_field_value(&self, field_id: &str) -> String {
+        use ui_core::form::{FieldValue, FormPath};
+        let parts: Vec<String> = field_id.split('.').map(|s| s.to_string()).collect();
+        let path = FormPath(parts);
+        if let Some(field_state) = self.form.state().get_field(&path) {
+            if let FieldValue::Text(ref v) = field_state.value {
+                return v.clone();
+            }
+        }
+        String::new()
+    }
+
+    /// Set the text value of a form field, forwarding an autofill value from
+    /// a hidden DOM `<input>` into the WASM form model.
+    ///
+    /// The `field_id` is the dot-separated path string for the field
+    /// (e.g. `"email"` or `"profile.name"`).  Non-existent paths are silently
+    /// ignored.  Only `FieldValue::Text` fields are updated; calling this on a
+    /// numeric or boolean field is a no-op.
+    ///
+    /// The update goes through `Form::set_value`, so it creates a history
+    /// snapshot and marks the field as touched/dirty, exactly as if the user
+    /// had typed the value themselves.
+    pub fn set_field_value(&mut self, field_id: &str, value: &str) {
+        use ui_core::form::{FieldValue, FormPath};
+        let parts: Vec<String> = field_id.split('.').map(|s| s.to_string()).collect();
+        let path = FormPath(parts);
+        // Only update if the field exists and holds a Text value.
+        if let Some(field_state) = self.form.state().get_field(&path) {
+            if matches!(field_state.value, FieldValue::Text(_)) {
+                let _ = self.form.set_value(&path, FieldValue::Text(value.to_string()));
+            }
+        }
+    }
+
+    /// Return a JSON array describing all form fields that have an autofill
+    /// hint set.  The JS `AutofillBridge` calls this once at init time to
+    /// know which hidden `<input>` elements to create.
+    ///
+    /// Each element in the array is an object with the shape:
+    /// ```json
+    /// { "id": "email", "autocomplete": "email", "type": "email" }
+    /// ```
+    ///
+    /// Returns `JsValue::NULL` on serialisation failure (should not happen in
+    /// practice).
+    pub fn list_autofill_fields(&self) -> JsValue {
+        // Build a JSON array of { id, autocomplete, type } objects for all
+        // fields that carry an AutocompleteHint, then serialise to JsValue.
+        let schema = self.form.schema();
+        let arr = Self::collect_autofill_json(schema.fields.as_slice(), "");
+        match serde_wasm_bindgen::to_value(&arr) {
+            Ok(v) => v,
+            Err(_) => JsValue::NULL,
+        }
+    }
+
+    /// Recursive helper that collects autofill-annotated fields into a
+    /// `Vec<serde_json::Value>`, walking into `Group` fields.
+    fn collect_autofill_json(
+        fields: &[ui_core::form::FieldSchema],
+        prefix: &str,
+    ) -> Vec<serde_json::Value> {
+        let mut out = Vec::new();
+        for field in fields {
+            let full_id: String = if prefix.is_empty() {
+                field.id.clone()
+            } else {
+                format!("{}.{}", prefix, field.id)
+            };
+
+            if let Some(ref hint) = field.autocomplete {
+                out.push(serde_json::json!({
+                    "id": full_id,
+                    "autocomplete": hint.as_str(),
+                    "type": hint.input_type(),
+                }));
+            }
+
+            if let ui_core::form::FieldType::Group { fields: ref children, .. } = field.field_type {
+                let child_prefix: String = if prefix.is_empty() {
+                    field.id.clone()
+                } else {
+                    format!("{}.{}", prefix, field.id)
+                };
+                out.extend(Self::collect_autofill_json(children, &child_prefix));
+            }
+        }
+        out
+    }
+
+    // -----------------------------------------------------------------
     // Context loss
     // -----------------------------------------------------------------
 

--- a/examples/web/app.js
+++ b/examples/web/app.js
@@ -356,6 +356,134 @@ class AccessibilityMirror {
   }
 }
 
+// ---------------------------------------------------------------------------
+// AutofillBridge — hidden DOM <form> with <input> elements that expose the
+// GPU-rendered form fields to browser autofill and third-party password
+// managers (1Password, Bitwarden, etc.).
+//
+// Password managers locate credential fields by scanning the DOM for
+// <input autocomplete="current-password"> (or similar) inside a <form>.
+// Because wham renders entirely on a <canvas>, those inputs don't exist
+// by default.  The AutofillBridge creates them off-screen (1 × 1 px,
+// opacity:0, position:absolute, left:-9999px) — NOT display:none, which
+// causes most password managers to ignore them.
+//
+// Flow:
+//   1. init()  — call list_autofill_fields() to discover annotated fields,
+//                create a hidden <form> with one <input> per field.
+//   2. input/change events on hidden inputs → set_field_value() → WASM.
+//   3. frame() → sync WASM field values back to hidden inputs so that
+//      browser save-password prompts see the current values.
+// ---------------------------------------------------------------------------
+class AutofillBridge {
+  /**
+   * @param {WasmApp} app   Reference to the Wasm application.
+   */
+  constructor(app) {
+    this._app = app;
+    /** @type {Map<string, HTMLInputElement>} fieldId -> hidden <input> */
+    this._inputs = new Map();
+    /** @type {HTMLFormElement|null} */
+    this._form = null;
+  }
+
+  /**
+   * Query the WASM runtime for autofill-annotated fields and create a hidden
+   * DOM <form> with corresponding <input> elements.
+   *
+   * Call this once after the WasmApp is constructed.  Safe to call multiple
+   * times — subsequent calls replace the previous hidden form.
+   */
+  init() {
+    // Tear down any previous form (e.g. if schema changed).
+    if (this._form) {
+      this._form.remove();
+      this._inputs.clear();
+    }
+
+    const fields = this._app.list_autofill_fields();
+    if (!Array.isArray(fields) || fields.length === 0) return;
+
+    // Wrap inputs in a <form> so password managers recognise them.
+    const form = document.createElement("form");
+    form.setAttribute("action", "#");
+    form.setAttribute("method", "post");
+    form.setAttribute("aria-hidden", "true");
+    // Off-screen, 1×1, opacity:0 — NOT display:none (password managers skip those).
+    Object.assign(form.style, {
+      position: "absolute",
+      left: "-9999px",
+      top: "-9999px",
+      width: "1px",
+      height: "1px",
+      opacity: "0",
+      pointerEvents: "none",
+      // Contain layout impact.
+      overflow: "hidden",
+    });
+    document.body.appendChild(form);
+    this._form = form;
+
+    for (const { id, autocomplete, type } of fields) {
+      const input = document.createElement("input");
+      input.setAttribute("autocomplete", autocomplete);
+      input.setAttribute("type", type || "text");
+      input.setAttribute("name", id);
+      input.setAttribute("id", `wham-autofill-${id.replace(/\./g, "-")}`);
+      input.setAttribute("tabindex", "-1");
+      // Prevent IME / spellcheck activity on the hidden field.
+      input.setAttribute("autocorrect", "off");
+      input.setAttribute("autocapitalize", "off");
+      input.setAttribute("spellcheck", "false");
+      Object.assign(input.style, {
+        width: "1px",
+        height: "1px",
+        opacity: "0",
+        pointerEvents: "none",
+      });
+
+      // Forward autofill values from the hidden input into WASM.
+      // Both "input" and "change" are needed:
+      //   - "input"  fires on every keystroke / programmatic injection.
+      //   - "change" fires when the user selects from a password manager
+      //     dropdown (some managers only fire "change", not "input").
+      // Browsers do NOT fire "input"/"change" when `input.value` is set
+      // programmatically, so syncToDOM() will not cause feedback loops.
+      const forward = () => {
+        this._app.set_field_value(id, input.value);
+      };
+      input.addEventListener("input", forward);
+      input.addEventListener("change", forward);
+
+      form.appendChild(input);
+      this._inputs.set(id, input);
+    }
+  }
+
+  /**
+   * Sync the current WASM field values back into the hidden inputs.
+   *
+   * Call this once per frame (after app.frame()) so that any programmatic
+   * changes to the WASM form state (e.g. the app setting a default email)
+   * are reflected in the hidden DOM inputs.  This ensures the browser's
+   * save-password prompt sees the final submitted values.
+   *
+   * Only updates inputs whose value has actually changed to avoid triggering
+   * spurious "change" events on every frame.
+   */
+  syncToDOM() {
+    for (const [id, input] of this._inputs) {
+      const wasmValue = this._app.get_field_value(id);
+      // Only update when the value differs to avoid redundant DOM mutations.
+      // Programmatic `value` assignment does NOT fire "input" or "change"
+      // events, so this cannot loop back into set_field_value().
+      if (input.value !== wasmValue) {
+        input.value = wasmValue;
+      }
+    }
+  }
+}
+
 function resize() {
   canvas.width = window.innerWidth * dpr;
   canvas.height = window.innerHeight * dpr;
@@ -711,6 +839,14 @@ async function main() {
 
   const hiddenTextarea = createHiddenTextarea();
   const a11yMirror = new AccessibilityMirror(canvas, app, dpr);
+
+  // --- Autofill / password-manager bridge ---
+  // Creates hidden <input> elements so that browser autofill and third-party
+  // password managers (1Password, Bitwarden, etc.) can discover and fill the
+  // GPU-rendered form fields.  Must be called after WasmApp is constructed so
+  // that list_autofill_fields() returns the correct schema.
+  const autofillBridge = new AutofillBridge(app);
+  autofillBridge.init();
 
   // --- Load fallback font (optional) ---
   // To support emoji or additional scripts, load a fallback font after the
@@ -1083,6 +1219,11 @@ async function main() {
     // that iOS Safari focus behaviour does not cause viewport scrolling.
     const focusedRect = app.focused_widget_rect();
     repositionTextarea(hiddenTextarea, focusedRect, dpr);
+
+    // Sync WASM field values → hidden DOM inputs so the browser's
+    // save-password prompt sees the latest state.  This is a no-op when no
+    // autofill fields are registered or when values have not changed.
+    autofillBridge.syncToDOM();
 
     requestAnimationFrame(frame);
   }


### PR DESCRIPTION
## Summary

- Adds `AutocompleteHint` enum to `ui-core::form` with variants for all common autofill tokens (`Email`, `CurrentPassword`, `NewPassword`, `Username`, `Name`, `GivenName`, `FamilyName`, `Custom`). Each variant knows its `autocomplete` attribute string and most appropriate `<input type>`.
- Adds `FieldSchema::autocomplete: Option<AutocompleteHint>` and `FormSchema::with_autocomplete()` builder method.
- Annotates the demo's login schema with `Email`/`CurrentPassword` and the register schema with `Email`/`NewPassword` hints.
- Adds `get_field_value`, `set_field_value`, and `list_autofill_fields` to `WasmRuntime` and exposes them through `WasmApp` via `wasm_bindgen`.
- Adds `AutofillBridge` class in `app.js` that creates a hidden off-screen `<form>` with one `<input>` per annotated field, forwards fill events into WASM, and syncs WASM values back to DOM each frame for save-password prompts.

## Implementation notes

- Hidden inputs are `position:absolute; left:-9999px; opacity:0; width:1px; height:1px` — **not** `display:none`, which causes most password managers to skip them.
- Browsers do not fire `input`/`change` events on programmatic `value` assignment, so `syncToDOM()` cannot loop back into `set_field_value()`.
- `list_autofill_fields` walks `Group` field trees so nested schemas are supported.
- All existing 196 `ui-core` tests pass; 5 new tests cover `AutocompleteHint` behaviour and the builder API.

## Test plan

- [ ] `cargo test -p ui-core` — 196 tests pass (5 new autocomplete tests)
- [ ] `cargo check -p ui-wasm --target wasm32-unknown-unknown` — no errors
- [ ] Manual browser test: open demo, open DevTools → Elements, verify a hidden `<form>` with `<input autocomplete="email">` and `<input autocomplete="current-password">` is present in the DOM
- [ ] Manual password manager test: use a password manager extension — confirm it offers to fill / save credentials in the login form
- [ ] Verify `display:none` is NOT used (would cause password managers to ignore the inputs)
- [ ] Verify no viewport scroll on mobile (hidden inputs are offscreen, not focused)

🤖 Generated with [Claude Code](https://claude.com/claude-code)