### PR TITLE
ci: headless form screenshot job with artifact upload (closes #127)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,39 @@ jobs:
 
       - name: Run clippy on ui-core
         run: cargo clippy -p ui-core --all-features -- -D warnings
+
+  # ── 4. Headless scenario tests + screenshot artifacts ───────────────────────
+  screenshots:
+    name: headless form screenshots
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-screenshots-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-screenshots-
+
+      - name: Run wham-test suite
+        run: cargo test -p wham-test
+
+      - name: Render scenario screenshots
+        run: |
+          mkdir -p tests/screenshots
+          WHAM_SCREENSHOT_DIR=tests/screenshots cargo test -p wham-test screenshot -- --nocapture
+
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: form-screenshots-${{ github.sha }}
+          path: tests/screenshots/
+          retention-days: 30

--- a/crates/wham-test/src/lib.rs
+++ b/crates/wham-test/src/lib.rs
@@ -171,6 +171,21 @@ impl VisualTest {
 // Public render helper
 // ---------------------------------------------------------------------------
 
+/// Render `build` and write the output to `{WHAM_SCREENSHOT_DIR}/{name}.png`.
+///
+/// Does nothing if the `WHAM_SCREENSHOT_DIR` environment variable is not set,
+/// making it safe to call from any test without side effects in normal runs.
+pub fn save_screenshot(name: &str, size: Size, build: impl Fn(&mut Ui)) {
+    let dir = match std::env::var("WHAM_SCREENSHOT_DIR") {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+    let pixels = render_to_pixels(size, build);
+    let path = std::path::PathBuf::from(&dir).join(format!("{}.png", name));
+    write_png(&path, size, &pixels)
+        .unwrap_or_else(|e| eprintln!("wham-test: screenshot failed for '{name}': {e}"));
+}
+
 /// Render a widget tree to a raw RGBA pixel buffer without performing any
 /// comparison.  Useful for generating reference snapshots programmatically.
 pub fn render_to_pixels(size: Size, build: impl Fn(&mut Ui)) -> Vec<u8> {

--- a/crates/wham-test/tests/checkout.rs
+++ b/crates/wham-test/tests/checkout.rs
@@ -184,3 +184,16 @@ fn checkout_submit_button_is_last_in_tab_order() {
     assert_eq!(last.kind, WidgetKind::Button, "last widget should be the submit button");
     assert!(last.label.contains("Place order"), "button label should reference the action");
 }
+
+#[test]
+fn checkout_screenshot() {
+    use std::cell::RefCell;
+    use wham_test::{save_screenshot, Size};
+
+    let form = RefCell::new(Form::new(schema()));
+    let country = RefCell::new("United States".to_string());
+
+    save_screenshot("checkout", Size { width: 640, height: 1000 }, |ui| {
+        checkout_view(ui, &mut form.borrow_mut(), &mut country.borrow_mut());
+    });
+}

--- a/crates/wham-test/tests/notification_settings.rs
+++ b/crates/wham-test/tests/notification_settings.rs
@@ -242,3 +242,25 @@ fn notification_save_button_emits_primary_colored_quad() {
         "at least one vertex must use the primary blue color (button or focus ring)"
     );
 }
+
+#[test]
+fn notification_settings_screenshot() {
+    use std::cell::RefCell;
+    use wham_test::{save_screenshot, Size};
+
+    let email_on = RefCell::new(true);
+    let push_on  = RefCell::new(false);
+    let sms_on   = RefCell::new(false);
+    let theme    = RefCell::new(0usize);
+
+    save_screenshot("notification_settings", Size { width: 480, height: 720 }, |ui| {
+        ui.set_icon_pack(notification_icon_pack());
+        notification_settings_view(
+            ui,
+            &mut email_on.borrow_mut(),
+            &mut push_on.borrow_mut(),
+            &mut sms_on.borrow_mut(),
+            &mut theme.borrow_mut(),
+        );
+    });
+}

--- a/crates/wham-test/tests/sign_in.rs
+++ b/crates/wham-test/tests/sign_in.rs
@@ -129,3 +129,18 @@ fn sign_in_typing_email_syncs_to_form() {
         other => panic!("expected FieldValue::Text, got {:?}", other),
     }
 }
+
+#[test]
+fn sign_in_screenshot() {
+    use std::cell::RefCell;
+    use ui_core::form::FieldValue;
+    use wham_test::{save_screenshot, Size};
+
+    let mut form = Form::new(schema());
+    form.set_value(&FormPath::root().push("email"), FieldValue::Text("alice@example.com".into()));
+
+    let form = RefCell::new(form);
+    save_screenshot("sign_in", Size { width: 480, height: 640 }, |ui| {
+        render(ui, &mut form.borrow_mut());
+    });
+}


### PR DESCRIPTION
## Summary

- Adds `save_screenshot` helper to `wham-test` (no-ops unless `WHAM_SCREENSHOT_DIR` is set)
- Adds `*_screenshot` test variants to sign-in, checkout, and notification settings scenario files
- Adds `screenshots` CI job that runs all wham-test tests, then renders and uploads form PNGs as a `form-screenshots` workflow artifact

## Artifact

After each CI run, download **form-screenshots** from the Actions summary to see:
- `sign_in.png` — 480×640 sign-in screen
- `checkout.png` — 640×1000 checkout form
- `notification_settings.png` — 480×720 settings screen

Screenshots become fully readable text once issue #126 (glyph rendering) merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)