### PR TITLE
fix(ci): use absolute GITHUB_WORKSPACE path for screenshot artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,13 +108,14 @@ jobs:
 
       - name: Render scenario screenshots
         run: |
-          mkdir -p tests/screenshots
-          WHAM_SCREENSHOT_DIR=tests/screenshots cargo test -p wham-test screenshot -- --nocapture
+          mkdir -p $GITHUB_WORKSPACE/tests/screenshots
+          WHAM_SCREENSHOT_DIR=$GITHUB_WORKSPACE/tests/screenshots \
+            cargo test -p wham-test screenshot -- --nocapture
 
       - name: Upload screenshots
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: form-screenshots-${{ github.sha }}
-          path: tests/screenshots/
+          name: form-screenshots
+          path: ${{ github.workspace }}/tests/screenshots/
           retention-days: 30


### PR DESCRIPTION
cargo test sets cwd to the package root (`crates/wham-test/`), so `WHAM_SCREENSHOT_DIR=tests/screenshots` resolved there — not in the repo root where `upload-artifact` was looking. Switch both `mkdir` and the env var to use `$GITHUB_WORKSPACE` so the path is consistent across all three steps.