### PR TITLE
fix(ci): delete intermediary screenshot artifacts after collecting into one zip

### DIFF
--- a/.github/workflows/test-cdp-runner.yml
+++ b/.github/workflows/test-cdp-runner.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  actions: write  # required to delete intermediary screenshot artifacts
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -324,3 +327,12 @@ jobs:
           name: browser-screenshots-${{ github.run_number }}
           path: all-screenshots/
           retention-days: 30
+
+      - name: Delete intermediary screenshot artifacts
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+            --jq '.artifacts[] | select(.name | startswith("screenshot-")) | .id' \
+          | xargs -I{} gh api "repos/${{ github.repository }}/actions/artifacts/{}" --method DELETE


### PR DESCRIPTION
## Problem

The workflow currently uploads 7 artifacts per run:
- 6 intermediary `screenshot-<name>-{run_id}` (one per test job)
- 1 final `browser-screenshots-{run_number}`

This is confusing in the Actions UI — it's not clear which one to download.

## Fix

After `collect-screenshots` merges all screenshots and uploads the final `browser-screenshots-N` artifact, a cleanup step deletes all `screenshot-*-{run_id}` intermediaries via the GitHub API.

Result: **one artifact** in the UI — `browser-screenshots-N`.

Also adds `permissions: actions: write` at the workflow level (required for the artifact DELETE API call).

## Test plan
- [ ] Only `browser-screenshots-N` appears in the Actions artifacts list after the run
- [ ] The combined artifact contains all screenshots from all test jobs
- [ ] Cleanup step does not fail if some test jobs produced no screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)